### PR TITLE
Make all decoding errors Text's

### DIFF
--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -1009,7 +1009,6 @@ class
     ToJSON (AttStmt a),
     Typeable a,
     Show a,
-    Exception (AttStmtDecodingError a),
     Exception (AttStmtVerificationError a)
   ) =>
   AttestationStatementFormat a
@@ -1076,17 +1075,13 @@ class
     VerifiableAttestationType ->
     X509.CertificateStore
 
-  -- | The type of decoding errors that can occur when decoding this
-  -- attestation statement using 'asfDecode'
-  type AttStmtDecodingError a :: Type
-
   -- | A decoder for the attestation statement [syntax](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats).
   -- The @attStmt@ CBOR map is given as an input. See
   -- [Generating an Attestation Object](https://www.w3.org/TR/webauthn-2/#sctn-generating-an-attestation-object)
   asfDecode ::
     a ->
     HashMap Text CBOR.Term ->
-    Either (AttStmtDecodingError a) (AttStmt a)
+    Either Text (AttStmt a)
 
   -- | An encoder for the attestation statement [syntax](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats).
   -- The @attStmt@ CBOR map is expected as the result. See

--- a/src/Crypto/WebAuthn/Operations/Assertion.hs
+++ b/src/Crypto/WebAuthn/Operations/Assertion.hs
@@ -23,6 +23,7 @@ where
 
 import qualified Codec.CBOR.Read as CBOR
 import Codec.Serialise (decode)
+import Control.Exception (Exception)
 import Control.Monad (unless)
 import qualified Crypto.Hash as Hash
 import qualified Crypto.WebAuthn.Cose.Key as Cose
@@ -34,6 +35,7 @@ import Data.ByteArray (convert)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.List.NonEmpty (NonEmpty)
+import Data.Text (Text)
 import Data.Validation (Validation)
 
 -- | Errors that may occur during [assertion](https://www.w3.org/TR/webauthn-2/#sctn-verifying-assertion)
@@ -69,8 +71,8 @@ data AssertionError
   | -- | The public key provided in the 'CredentialEntry' could not be decoded
     AssertionSignatureDecodingError CBOR.DeserialiseFailure
   | -- | the public key does verify the signature over the authData
-    AssertionInvalidSignature PublicKey.PublicKey BS.ByteString M.AssertionSignature String
-  deriving (Show)
+    AssertionInvalidSignature PublicKey.PublicKey BS.ByteString M.AssertionSignature Text
+  deriving (Show, Exception)
 
 -- | [Section 6.1.1 of the specification](https://www.w3.org/TR/webauthn-2/#sctn-sign-counter)
 -- describes the use of the signature counter, and describes what the relying

--- a/src/Crypto/WebAuthn/Operations/Attestation.hs
+++ b/src/Crypto/WebAuthn/Operations/Attestation.hs
@@ -27,6 +27,7 @@ module Crypto.WebAuthn.Operations.Attestation
   )
 where
 
+import Control.Exception (Exception)
 import Control.Monad (unless)
 import qualified Crypto.Hash as Hash
 import qualified Crypto.WebAuthn.Cose.Key as Cose
@@ -100,6 +101,8 @@ data AttestationError
     forall a. M.AttestationStatementFormat a => AttestationFormatError a (NonEmpty (M.AttStmtVerificationError a))
 
 deriving instance Show AttestationError
+
+deriving instance Exception AttestationError
 
 -- | Information about the [authenticator](https://www.w3.org/TR/webauthn-2/#authenticator)
 -- model that created the [public key credential](https://www.w3.org/TR/webauthn-2/#public-key-credential).

--- a/src/Crypto/WebAuthn/Operations/Attestation/None.hs
+++ b/src/Crypto/WebAuthn/Operations/Attestation/None.hs
@@ -23,7 +23,6 @@ instance M.AttestationStatementFormat Format where
   type AttStmt Format = ()
   asfIdentifier _ = "none"
 
-  type AttStmtDecodingError Format = Void
   asfDecode _ _ = Right ()
   asfEncode _ _ = CBOR.TMap []
 

--- a/tests/PublicKeySpec.hs
+++ b/tests/PublicKeySpec.hs
@@ -30,10 +30,10 @@ spec = do
 prop_x509PublicKeyRoundtrip :: PublicKey.PublicKey -> Bool
 prop_x509PublicKeyRoundtrip pubKey =
   case PublicKey.fromX509 (Key.toX509 pubKey) of
-    Just pubKey'
+    Right pubKey'
       | pubKey == pubKey' -> True
       | otherwise -> False
-    Nothing -> False
+    Left _ -> False
 
 prop_signverify :: Integer -> Key.KeyPair -> BS.ByteString -> Bool
 prop_signverify seed Key.KeyPair {..} msg = do


### PR DESCRIPTION
There's no good reason to want to catch separate decoding errors, so we
don't need structured error types for that. This commit also removes essentially all uses of `MonadFail`, because the only instantiation of it we use is `Maybe`, which discards the error completely.