### PR TITLE
Update cabal file with more fields and version bounds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,19 @@ let
 
   src = gitignoreSource ./.;
 
+  # Keep this in sync with the `tested-with` field in `webauthn.cabal`
+  expectedGhcVersion = "8.10.7";
+
   hpkgs = pkgs.haskellPackages.extend (hself: hsuper: {
+    ghc =
+      if hsuper.ghc.version != expectedGhcVersion then
+      throw
+        ( "We expect the default nixpkgs GHC version to be ${expectedGhcVersion}, "
+        + "but it is ${hsuper.ghc.version} instead. Update the `expectedGhcVersion` "
+        + "variable in `default.nix` and update the `tested-with` field in "
+        + "`webauthn.cabal` at the same time.")
+      else hsuper.ghc;
+
     webauthn = hself.callCabal2nix "webauthn" src {};
 
     jose = hself.callHackage "jose" "0.8.5" {};

--- a/webauthn.cabal
+++ b/webauthn.cabal
@@ -1,16 +1,31 @@
-cabal-version: 3.0
+cabal-version: 2.2
 name: webauthn
 version: 0.1.0.0
-maintainer: silvan.mosberger@tweag.io
-build-type: Simple
+license: Apache-2.0
 license-file: LICENSE
 copyright:
-  2020 - 2021: Arian van Putten
+  2020 - 2021: Arian van Putten,
   2021 -     : Tweag I/O
+author:
+  Silvan Mosberger <contact@infinisil.com>,
+  Erin van der Veen <erin@erinvanderveen.nl>,
+  Arian van Putten <arian.vanputten@gmail.com>,
+  Laurens Duijvesteijn <git@duijf.io>
+maintainer: Silvan Mosberger <contact@infinisil.com>
+stability: provisional
+homepage: https://github.com/tweag/webauthn
+bug-reports: https://github.com/tweag/webauthn/issues
+synopsis: Relying party (server) implementation of the WebAuthn 2 specification
+description:
+  Implements the [Relying Party conformance class](https://www.w3.org/TR/webauthn-2/#sctn-conforming-relying-parties)
+  of the [Web Authentication Level 2](https://www.w3.org/TR/webauthn-2/) specification.
+  This allows web applications to create strong, attested, scoped, public key-based
+  credentials for the purpose of strongly authenticating users.
+category: Web, Authentication
+tested-with: GHC == 8.10.7
 
 common sanity
   default-language: Haskell2010
-  build-depends: base
   ghc-options:
     -Wall
     -Wmissing-export-lists
@@ -32,40 +47,39 @@ library
   import: sanity
   hs-source-dirs: src
   build-depends:
+    base                  >= 4.14.3 && < 4.15,
     -- deriving-aeson has compilation performance problems with aeson >= 2.0,
     -- see https://github.com/fumieval/deriving-aeson/issues/16
-    aeson < 2.0,
-    asn1-encoding,
-    asn1-parse,
-    asn1-types,
-    base16-bytestring,
-    base64-bytestring,
-    binary,
-    bytestring,
-    cborg,
-    containers,
-    cryptonite,
-    deriving-aeson,
-    file-embed,
-    hashable,
-    hourglass,
-    -- https://github.com/frasertweedale/hs-jose/pull/103#issuecomment-923624548
-    jose >= 0.8.5,
-    lens,
-    memory,
-    monad-time,
-    mtl,
-    serialise,
-    singletons,
-    text,
-    time,
-    unordered-containers,
-    uuid,
-    validation,
-    x509,
-    x509-store,
-    -- https://github.com/vincenthz/hs-certificate/pull/126
-    x509-validation >= 1.6.12
+    aeson                 >= 1.5.6 && < 2.0,
+    asn1-encoding         >= 0.9.6 && < 0.10,
+    asn1-parse            >= 0.9.5 && < 0.10,
+    asn1-types            >= 0.3.4 && < 0.4,
+    base16-bytestring     >= 1.0.2 && < 1.1,
+    base64-bytestring     >= 1.2.1 && < 1.3,
+    binary                >= 0.8.8 && < 0.9,
+    bytestring            >= 0.10.12 && < 0.11,
+    cborg                 >= 0.2.6 && < 0.3,
+    containers            >= 0.6.5 && < 0.7,
+    cryptonite            >= 0.29 && < 0.30,
+    deriving-aeson        >= 0.2.8 && < 0.3,
+    file-embed            >= 0.0.15 && < 0.1,
+    hashable              >= 1.3.0 && < 1.4,
+    hourglass             >= 0.2.12 && < 0.3,
+    jose                  >= 0.8.5 && < 0.9,
+    lens                  >= 4.19.2 && < 4.20,
+    memory                >= 0.15.0 && < 0.16,
+    monad-time            >= 0.3.1 && < 0.4,
+    mtl                   >= 2.2.2 && < 2.3,
+    serialise             >= 0.2.4 && < 0.3,
+    singletons            >= 2.7 && < 2.8,
+    text                  >= 1.2.4 && < 1.3,
+    time                  >= 1.9.3 && < 1.10,
+    unordered-containers  >= 0.2.16 && < 0.3,
+    uuid                  >= 1.3.15 && < 1.4,
+    validation            >= 1.1.2 && < 1.2,
+    x509                  >= 1.7.5 && < 1.8,
+    x509-store            >= 1.6.7 && < 1.7,
+    x509-validation       >= 1.6.12 && < 1.7
   exposed-modules:
     Crypto.WebAuthn.Cose.Key,
     Crypto.WebAuthn.Cose.Registry,
@@ -113,37 +127,38 @@ executable server
     PendingOps
 
   build-depends:
-    aeson < 2.0,
-    aeson-pretty,
-    base64-bytestring,
-    binary,
-    cborg,
-    clock >= 0.6.0,
-    bytestring,
-    containers,
-    cookie,
-    cryptonite,
+    base                  >= 4.14.3 && < 4.15,
+    aeson                 >= 1.5.6 && < 2.0,
+    bytestring            >= 0.10.12 && < 0.11,
+    containers            >= 0.6.5 && < 0.7,
+    binary                >= 0.8.8 && < 0.9,
+    text                  >= 1.2.4 && < 1.3,
+    transformers          >= 0.5.6 && < 0.6,
+    mtl                   >= 2.2.2 && < 2.3,
+    hourglass             >= 0.2.12 && < 0.3,
+    base64-bytestring     >= 1.2.1 && < 1.3,
+    cborg                 >= 0.2.6 && < 0.3,
+    cryptonite            >= 0.29 && < 0.30,
+    jose                  >= 0.8.5 && < 0.9,
+    stm                   >= 2.5.0 && < 2.6,
+    x509                  >= 1.7.5 && < 1.8,
+    pem                   >= 0.2.4 && < 0.3,
+    singletons            >= 2.7 && < 2.8,
+    uuid                  >= 1.3.15 && < 1.4,
+    validation            >= 1.1.2 && < 1.2,
+    x509-validation       >= 1.6.12 && < 1.7,
+    aeson-pretty          >= 0.8.9 && < 0.9,
+    clock                 >= 0.8.2 && < 0.9,
+    cookie                >= 0.4.5 && < 0.5,
+    http-client           >= 0.6.4 && < 0.7,
+    http-types            >= 0.12.3 && < 0.13,
+    http-client-tls       >= 0.3.5 && < 0.4,
+    scotty                >= 0.12 && < 0.13,
+    wai                   >= 3.2.3 && < 3.3,
+    warp                  >= 3.3.18 && < 3.4,
     webauthn,
-    hourglass,
-    http-client,
-    http-client-tls,
-    http-types,
-    jose,
-    mtl,
-    pem,
-    scotty,
-    singletons,
-    sqlite-simple,
-    stm,
-    text,
-    transformers,
-    uuid,
-    validation,
-    wai,
-    wai-middleware-static,
-    warp,
-    x509,
-    x509-validation,
+    sqlite-simple         >= 0.4.18 && < 0.5,
+    wai-middleware-static >= 0.9.1 && < 0.10,
 
 test-suite tests
   import: sanity
@@ -165,8 +180,9 @@ test-suite tests
     Emulation.Authenticator,
     Emulation.Authenticator.Arbitrary
   build-depends:
+    base,
     QuickCheck,
-    aeson < 2.0,
+    aeson,
     asn1-encoding,
     base64-bytestring,
     binary,


### PR DESCRIPTION
Version bounds that weren't specified already before this commit were generated
with `cabal gen-bounds`, and may therefore be more restrictive than
necessary. These bounds can be relaxed in the future as needed.

Resolves #56 