### PR TITLE
Explicitly declare kinds, improve singleton instances

### DIFF
--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -910,7 +910,7 @@ data CollectedClientData (c :: CeremonyKind) raw = CollectedClientData
   }
   deriving (Eq, Show)
 
-instance SingI c => ToJSON (CollectedClientData c raw) where
+instance SingI c => ToJSON (CollectedClientData (c :: CeremonyKind) raw) where
   toJSON CollectedClientData {..} =
     object
       [ "webauthnKind" .= sing @c,

--- a/src/Crypto/WebAuthn/Model/WebIDL/Internal/Binary/Decoding.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL/Internal/Binary/Decoding.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -223,7 +224,7 @@ data ClientDataJSON = ClientDataJSON
 -- to parse the [clientDataJSON](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson)
 -- field in the [AuthenticatorResponse](https://www.w3.org/TR/webauthn-2/#iface-authenticatorresponse)
 -- structure, which is used for both attestation and assertion
-decodeCollectedClientData :: forall c. SingI c => BS.ByteString -> Either Text (M.CollectedClientData c 'True)
+decodeCollectedClientData :: forall (c :: K.CeremonyKind). SingI c => BS.ByteString -> Either Text (M.CollectedClientData c 'True)
 decodeCollectedClientData bytes = do
   -- https://www.w3.org/TR/webauthn-2/#collectedclientdata-json-compatible-serialization-of-client-data
   ClientDataJSON {..} <-

--- a/src/Crypto/WebAuthn/Model/WebIDL/Internal/Binary/Encoding.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL/Internal/Binary/Encoding.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -42,7 +43,7 @@ import Data.Word (Word16, Word8)
 -- | Encodes all raw fields of a 'M.Credential'. This function is
 -- mainly useful for testing that the encoding/decoding functions are correct.
 -- The counterpart to this function is 'Crypto.WebAuthn.Model.Binary.Decoding.stripRawCredential'
-encodeRawCredential :: forall c raw. SingI c => M.Credential c raw -> M.Credential c 'True
+encodeRawCredential :: forall (c :: K.CeremonyKind) raw. SingI c => M.Credential c raw -> M.Credential c 'True
 encodeRawCredential M.Credential {..} =
   M.Credential
     { cResponse = case sing @c of
@@ -132,7 +133,7 @@ encodeRawAuthenticatorData M.AuthenticatorData {..} =
         credentialLength :: Word16
         credentialLength = fromIntegral $ BS.length $ M.unCredentialId acdCredentialId
 
-    encodeRawAttestedCredentialData :: forall c raw. SingI c => M.AttestedCredentialData c raw -> M.AttestedCredentialData c 'True
+    encodeRawAttestedCredentialData :: forall (c :: K.CeremonyKind) raw. SingI c => M.AttestedCredentialData c raw -> M.AttestedCredentialData c 'True
     encodeRawAttestedCredentialData = case sing @c of
       K.SRegistration -> \M.AttestedCredentialData {..} ->
         M.AttestedCredentialData
@@ -195,5 +196,5 @@ encodeAttestationObject M.AttestationObject {..} = CBOR.toStrictByteString $ CBO
 
 -- | Encodes an 'M.CollectedClientData' as a 'BS.ByteString'. This is needed by
 -- the client side to generate a valid JSON response
-encodeCollectedClientData :: forall c. SingI c => M.CollectedClientData c 'True -> BS.ByteString
+encodeCollectedClientData :: forall (c :: K.CeremonyKind). SingI c => M.CollectedClientData c 'True -> BS.ByteString
 encodeCollectedClientData M.CollectedClientData {..} = M.unRaw ccdRawData

--- a/src/Crypto/WebAuthn/Model/WebIDL/Internal/Decoding.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL/Internal/Decoding.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Stability: internal
@@ -56,7 +57,7 @@ instance Decode M.AuthenticationExtensionsClientOutputs where
   -- module documentation of `Crypto.WebAuthn.Model` for more information.
   decode _ = pure M.AuthenticationExtensionsClientOutputs {}
 
-instance SingI c => Decode (M.CollectedClientData c 'True) where
+instance SingI c => Decode (M.CollectedClientData (c :: K.CeremonyKind) 'True) where
   decode (IDL.URLEncodedBase64 bytes) = B.decodeCollectedClientData bytes
 
 instance Decode (M.AuthenticatorData 'K.Authentication 'True) where

--- a/src/Crypto/WebAuthn/Model/WebIDL/Internal/Encoding.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL/Internal/Encoding.hs
@@ -185,7 +185,7 @@ instance Encode (M.Credential 'K.Registration 'True) where
       }
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson)
-instance SingI c => Encode (M.CollectedClientData c 'True) where
+instance SingI c => Encode (M.CollectedClientData (c :: K.CeremonyKind) 'True) where
   encode ccd = IDL.URLEncodedBase64 $ B.encodeCollectedClientData ccd
 
 instance Encode (M.AuthenticatorResponse 'K.Authentication 'True) where


### PR DESCRIPTION
The kind declarations are not necessary - GHC infers the kind like `CeremonyKind` using the local bindings under `case`. Declaring kind makes it easier to read the type signatures.

Also, I simplified a few places around the singleton logic and replaces instances created for the singleton constructors with the instances for the regular data type.