### PR TITLE
Drop dependency on deriving-aeson; update to Aeson 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     - name: "Nix build"
-      run: nix-build -A webauthn -A server
+      run: nix-build -A webauthn -A server -A webauthn_aeson1
 
   dev:
     runs-on: ${{ matrix.os }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+### Next version
+
+* [#115](https://github.com/tweag/webauthn/pull/115) Increase the upper bound
+  of the supported Aeson versions, allowing the library to be built with Aeson
+  2.x. Drop the deriving-aeson dependency.
+
 ### 0.1.1.0
 
 * [#111](https://github.com/tweag/webauthn/pull/111) Support the

--- a/default.nix
+++ b/default.nix
@@ -32,15 +32,39 @@ let
 
     server = hself.callCabal2nix "server" (src + "/server") {};
 
-    jose = hself.callHackage "jose" "0.8.5" {};
+    jose = hself.jose_0_9;
 
     base64-bytestring = hself.base64-bytestring_1_2_1_0;
+
+    aeson = hself.aeson_2_0_3_0;
+
+    OneTuple = hself.OneTuple_0_3_1;
+
+    hashable = hself.hashable_1_4_0_1;
+
+    quickcheck-instances = hself.quickcheck-instances_0_3_27;
+
+    text-short = pkgs.haskell.lib.dontCheck hself.text-short_0_1_5;
+
+    semialign = hself.semialign_1_2_0_1;
+
+    hspec-expectations-json = pkgs.haskell.lib.dontCheck hself.hspec-expectations-json_1_0_0_5;
+
+    attoparsec = hself.attoparsec_0_14_3;
+
+    time-compat = hself.time-compat_1_9_6_1;
 
     x509-validation = hself.callHackageDirect {
       pkg = "x509-validation";
       ver = "1.6.12";
       sha256 = "1jrsryn6hfdmr1b1alpj5zxvw26dw8y7kqpq555q2njm3kvwmxap";
     } {};
+
+    # Needed for aeson 2.0
+    http2 = pkgs.haskell.lib.appendPatch hsuper.http2 (pkgs.fetchpatch {
+      url = "https://github.com/kazu-yamamoto/http2/commit/0a1f64cb7cd2042554cd2d4e96da850a8940f08d.patch";
+      sha256 = "0kbbd7dv49m6slcfw61kzy21v4d2ingnbygg4i3spn91v3dyh87y";
+    });
   });
 
   deploy = pkgs.writeShellScriptBin "deploy" ''

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
-        "sha256": "0izvjizdn0mil4qasdial3hbparzzpx61v0l9zb7bbwss428x1i9",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "sha256": "0kngzmn69izr8xcmjiqsyhs80iha00q4nbmj1vs49jrha5ncy8s1",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0432195a4b8d68faaa7d3d4b355260a3120aeeae.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/server/server.cabal
+++ b/server/server.cabal
@@ -31,7 +31,7 @@ executable server
 
   build-depends:
     base                  >= 4.14.3 && < 4.15,
-    aeson                 >= 1.5.6 && < 1.6,
+    aeson                 >= 1.5.6 && < 3.0,
     bytestring            >= 0.10.12 && < 0.11,
     containers            >= 0.6.5 && < 0.7,
     binary                >= 0.8.8 && < 0.9,

--- a/src/Crypto/WebAuthn/Metadata/FidoRegistry.hs
+++ b/src/Crypto/WebAuthn/Metadata/FidoRegistry.hs
@@ -15,9 +15,8 @@ module Crypto.WebAuthn.Metadata.FidoRegistry
   )
 where
 
-import Crypto.WebAuthn.Internal.Utils (EnumJSONEncoding)
+import Crypto.WebAuthn.Internal.Utils (enumJSONEncodingOptions)
 import qualified Data.Aeson as Aeson
-import Deriving.Aeson (CustomJSON (CustomJSON))
 import GHC.Generics (Generic)
 
 -- | [(spec)](https://fidoalliance.org/specs/common-specs/fido-registry-v2.1-ps-20191217.html#user-verification-methods)
@@ -36,7 +35,12 @@ data UserVerificationMethod
   | USER_VERIFY_NONE
   | USER_VERIFY_ALL
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via EnumJSONEncoding "USER_VERIFY_" UserVerificationMethod
+
+instance Aeson.FromJSON UserVerificationMethod where
+  parseJSON = Aeson.genericParseJSON $ enumJSONEncodingOptions "USER_VERIFY_"
+
+instance Aeson.ToJSON UserVerificationMethod where
+  toJSON = Aeson.genericToJSON $ enumJSONEncodingOptions "USER_VERIFY_"
 
 -- | [(spec)](https://fidoalliance.org/specs/common-specs/fido-registry-v2.1-ps-20191217.html#key-protection-types)
 data KeyProtectionType
@@ -46,7 +50,12 @@ data KeyProtectionType
   | KEY_PROTECTION_SECURE_ELEMENT
   | KEY_PROTECTION_REMOTE_HANDLE
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via EnumJSONEncoding "KEY_PROTECTION_" KeyProtectionType
+
+instance Aeson.FromJSON KeyProtectionType where
+  parseJSON = Aeson.genericParseJSON $ enumJSONEncodingOptions "KEY_PROTECTION_"
+
+instance Aeson.ToJSON KeyProtectionType where
+  toJSON = Aeson.genericToJSON $ enumJSONEncodingOptions "KEY_PROTECTION_"
 
 -- | [(spec)](https://fidoalliance.org/specs/common-specs/fido-registry-v2.1-ps-20191217.html#matcher-protection-types)
 data MatcherProtectionType
@@ -54,7 +63,12 @@ data MatcherProtectionType
   | MATCHER_PROTECTION_TEE
   | MATCHER_PROTECTION_ON_CHIP
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via EnumJSONEncoding "MATCHER_PROTECTION_" MatcherProtectionType
+
+instance Aeson.FromJSON MatcherProtectionType where
+  parseJSON = Aeson.genericParseJSON $ enumJSONEncodingOptions "MATCHER_PROTECTION_"
+
+instance Aeson.ToJSON MatcherProtectionType where
+  toJSON = Aeson.genericToJSON $ enumJSONEncodingOptions "MATCHER_PROTECTION_"
 
 -- | [(spec)](https://fidoalliance.org/specs/common-specs/fido-registry-v2.1-ps-20191217.html#authenticator-attachment-hints)
 data AuthenticatorAttachmentHint
@@ -68,7 +82,12 @@ data AuthenticatorAttachmentHint
   | ATTACHMENT_HINT_READY
   | ATTACHMENT_HINT_WIFI_DIRECT
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via EnumJSONEncoding "ATTACHMENT_HINT_" AuthenticatorAttachmentHint
+
+instance Aeson.FromJSON AuthenticatorAttachmentHint where
+  parseJSON = Aeson.genericParseJSON $ enumJSONEncodingOptions "ATTACHMENT_HINT_"
+
+instance Aeson.ToJSON AuthenticatorAttachmentHint where
+  toJSON = Aeson.genericToJSON $ enumJSONEncodingOptions "ATTACHMENT_HINT_"
 
 -- | [(spec)](https://fidoalliance.org/specs/common-specs/fido-registry-v2.1-ps-20191217.html#transaction-confirmation-display-types)
 data TransactionConfirmationDisplayType
@@ -78,7 +97,12 @@ data TransactionConfirmationDisplayType
   | TRANSACTION_CONFIRMATION_DISPLAY_HARDWARE
   | TRANSACTION_CONFIRMATION_DISPLAY_REMOTE
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via EnumJSONEncoding "TRANSACTION_CONFIRMATION_DISPLAY_" TransactionConfirmationDisplayType
+
+instance Aeson.FromJSON TransactionConfirmationDisplayType where
+  parseJSON = Aeson.genericParseJSON $ enumJSONEncodingOptions "TRANSACTION_CONFIRMATION_DISPLAY_"
+
+instance Aeson.ToJSON TransactionConfirmationDisplayType where
+  toJSON = Aeson.genericToJSON $ enumJSONEncodingOptions "TRANSACTION_CONFIRMATION_DISPLAY_"
 
 -- | [(spec)](https://fidoalliance.org/specs/common-specs/fido-registry-v2.1-ps-20191217.html#authentication-algorithms)
 data AuthenticationAlgorithm
@@ -101,7 +125,12 @@ data AuthenticationAlgorithm
   | ALG_SIGN_SECP512R1_ECDSA_SHA512_RAW
   | ALG_SIGN_ED25519_EDDSA_SHA512_RAW
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via EnumJSONEncoding "ALG_SIGN_" AuthenticationAlgorithm
+
+instance Aeson.FromJSON AuthenticationAlgorithm where
+  parseJSON = Aeson.genericParseJSON $ enumJSONEncodingOptions "ALG_SIGN_"
+
+instance Aeson.ToJSON AuthenticationAlgorithm where
+  toJSON = Aeson.genericToJSON $ enumJSONEncodingOptions "ALG_SIGN_"
 
 -- | [(spec)](https://fidoalliance.org/specs/common-specs/fido-registry-v2.1-ps-20191217.html#public-key-representation-formats)
 data PublicKeyRepresentationFormat
@@ -111,7 +140,12 @@ data PublicKeyRepresentationFormat
   | ALG_KEY_RSA_2048_DER
   | ALG_KEY_COSE
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via EnumJSONEncoding "ALG_KEY_" PublicKeyRepresentationFormat
+
+instance Aeson.FromJSON PublicKeyRepresentationFormat where
+  parseJSON = Aeson.genericParseJSON $ enumJSONEncodingOptions "ALG_KEY_"
+
+instance Aeson.ToJSON PublicKeyRepresentationFormat where
+  toJSON = Aeson.genericToJSON $ enumJSONEncodingOptions "ALG_KEY_"
 
 -- | [(spec)](https://fidoalliance.org/specs/common-specs/fido-registry-v2.1-ps-20191217.html#authenticator-attestation-types)
 data AuthenticatorAttestationType
@@ -120,4 +154,9 @@ data AuthenticatorAttestationType
   | ATTESTATION_ECDAA
   | ATTESTATION_ATTCA
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via EnumJSONEncoding "ATTESTATION_" AuthenticatorAttestationType
+
+instance Aeson.FromJSON AuthenticatorAttestationType where
+  parseJSON = Aeson.genericParseJSON $ enumJSONEncodingOptions "ATTESTATION_"
+
+instance Aeson.ToJSON AuthenticatorAttestationType where
+  toJSON = Aeson.genericToJSON $ enumJSONEncodingOptions "ATTESTATION_"

--- a/src/Crypto/WebAuthn/Metadata/Service/Processing.hs
+++ b/src/Crypto/WebAuthn/Metadata/Service/Processing.hs
@@ -45,6 +45,7 @@ import Crypto.JWT
 import Crypto.WebAuthn.Internal.DateOrphans ()
 import Crypto.WebAuthn.Metadata.Service.Decode (decodeMetadataPayload)
 import qualified Crypto.WebAuthn.Metadata.Service.Types as Service
+import qualified Crypto.WebAuthn.Metadata.Service.WebIDL as ServiceIDL
 import qualified Crypto.WebAuthn.Model as M
 import Crypto.WebAuthn.Model.Identifier
   ( AAGUID,
@@ -56,12 +57,12 @@ import Crypto.WebAuthn.Model.Identifier
       ),
     SubjectKeyIdentifier,
   )
-import Data.Aeson (Value (Object))
-import qualified Data.Aeson as Aeson
+import Data.Aeson (Value)
+import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.FileEmbed (embedFile)
-import Data.HashMap.Strict (HashMap)
+import Data.HashMap.Strict (HashMap, (!?))
 import qualified Data.HashMap.Strict as HashMap
 import Data.Hourglass (DateTime)
 import qualified Data.List.NonEmpty as NE
@@ -72,6 +73,7 @@ import qualified Data.Text as Text
 import qualified Data.X509 as X509
 import qualified Data.X509.CertificateStore as X509
 import qualified Data.X509.Validation as X509
+import GHC.Exts (fromList, toList)
 
 -- | A root certificate along with the host it should be verified against
 data RootCertificate = RootCertificate
@@ -179,7 +181,7 @@ jwtToJson ::
 jwtToJson blob rootCert now = runExcept $ do
   jwt <- decodeCompact $ LBS.fromStrict blob
   claims <- runReaderT (verifyClaims (defaultJWTValidationSettings (const True)) rootCert jwt) now
-  return $ claims ^. unregisteredClaims
+  return . fromList . toList $ claims ^. unregisteredClaims
 
 -- | Decodes a FIDO Metadata payload JSON value to a 'Service.MetadataPayload',
 -- returning an error when the JSON is invalid, and ignoring any entries not
@@ -188,11 +190,22 @@ jwtToJson blob rootCert now = runExcept $ do
 -- and `Crypto.WebAuthn.Metadata.Service.Types.mpEntries` fields are most
 -- important.
 jsonToPayload :: HashMap Text Value -> Either Text Service.MetadataPayload
-jsonToPayload value = case Aeson.fromJSON $ Object value of
-  Aeson.Error err -> Left $ Text.pack err
-  Aeson.Success payload -> case decodeMetadataPayload payload of
+jsonToPayload value = case Aeson.parseEither metadataPayloadParser value of
+  Left err -> Left $ Text.pack err
+  Right payload -> case decodeMetadataPayload payload of
     Left err -> Left err
     Right result -> pure result
+
+metadataPayloadParser :: HashMap Text Aeson.Value -> Aeson.Parser ServiceIDL.MetadataBLOBPayload
+metadataPayloadParser hm = case (hm !? "legalHeader", hm !? "no", hm !? "nextUpdate", hm !? "entries") of
+  (Just legalHeader, Just no, Just nextUpdate, Just entries) -> do
+    legalHeader <- Aeson.parseJSON legalHeader
+    no <- Aeson.parseJSON no
+    nextUpdate <- Aeson.parseJSON nextUpdate
+    entries <- Aeson.parseJSON entries
+    pure $
+      ServiceIDL.MetadataBLOBPayload {..}
+  _ -> fail "Could not decode MetadataBLOB: missing fields"
 
 -- | Creates a 'Service.MetadataServiceRegistry' from a list of
 -- 'Service.SomeMetadataEntry', which can either be obtained from a

--- a/src/Crypto/WebAuthn/Metadata/Service/WebIDL.hs
+++ b/src/Crypto/WebAuthn/Metadata/Service/WebIDL.hs
@@ -17,7 +17,7 @@ where
 -- Unless otherwise specified, if a WebIDL dictionary member is DOMString, it MUST NOT be empty.
 -- Unless otherwise specified, if a WebIDL dictionary member is a List, it MUST NOT be an empty list.
 
-import Crypto.WebAuthn.Internal.Utils (CustomJSON (CustomJSON), JSONEncoding)
+import Crypto.WebAuthn.Internal.Utils (jsonEncodingOptions)
 import Crypto.WebAuthn.Metadata.Statement.WebIDL (AAGUID, MetadataStatement)
 import qualified Crypto.WebAuthn.Metadata.UAF as UAF
 import qualified Crypto.WebAuthn.WebIDL as IDL
@@ -46,7 +46,12 @@ data MetadataBLOBPayloadEntry = MetadataBLOBPayloadEntry
     -- entryRogueListHash :: IDL.DOMString
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding MetadataBLOBPayloadEntry
+
+instance Aeson.FromJSON MetadataBLOBPayloadEntry where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON MetadataBLOBPayloadEntry where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#biometricstatusreport-dictionary)
 data BiometricStatusReport = BiometricStatusReport
@@ -66,7 +71,12 @@ data BiometricStatusReport = BiometricStatusReport
     certificationRequirementsVersion :: Maybe IDL.DOMString
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding BiometricStatusReport
+
+instance Aeson.FromJSON BiometricStatusReport where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON BiometricStatusReport where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#statusreport-dictionary)
 data StatusReport = StatusReport
@@ -90,7 +100,12 @@ data StatusReport = StatusReport
     certificationRequirementsVersion :: Maybe IDL.DOMString
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding StatusReport
+
+instance Aeson.FromJSON StatusReport where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON StatusReport where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#authenticatorstatus-enum)
 data AuthenticatorStatus
@@ -110,7 +125,12 @@ data AuthenticatorStatus
   | FIDO_CERTIFIED_L3
   | FIDO_CERTIFIED_L3plus
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding AuthenticatorStatus
+
+instance Aeson.FromJSON AuthenticatorStatus where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON AuthenticatorStatus where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#metadata-blob-payload-dictionary)
 data MetadataBLOBPayload = MetadataBLOBPayload
@@ -124,4 +144,9 @@ data MetadataBLOBPayload = MetadataBLOBPayload
     entries :: [MetadataBLOBPayloadEntry]
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding MetadataBLOBPayload
+
+instance Aeson.FromJSON MetadataBLOBPayload where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON MetadataBLOBPayload where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions

--- a/src/Crypto/WebAuthn/Metadata/Statement/WebIDL.hs
+++ b/src/Crypto/WebAuthn/Metadata/Statement/WebIDL.hs
@@ -26,7 +26,7 @@ module Crypto.WebAuthn.Metadata.Statement.WebIDL
   )
 where
 
-import Crypto.WebAuthn.Internal.Utils (CustomJSON (CustomJSON), EnumJSONEncoding, JSONEncoding)
+import Crypto.WebAuthn.Internal.Utils (enumJSONEncodingOptions, jsonEncodingOptions)
 import qualified Crypto.WebAuthn.Metadata.FidoRegistry as Registry
 import qualified Crypto.WebAuthn.Metadata.UAF as UAF
 import qualified Crypto.WebAuthn.WebIDL as IDL
@@ -53,7 +53,12 @@ data CodeAccuracyDescriptor = CodeAccuracyDescriptor
     blockSlowdown :: Maybe IDL.UnsignedShort
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding CodeAccuracyDescriptor
+
+instance Aeson.FromJSON CodeAccuracyDescriptor where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON CodeAccuracyDescriptor where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#biometricaccuracydescriptor-dictionary)
 data BiometricAccuracyDescriptor = BiometricAccuracyDescriptor
@@ -69,7 +74,12 @@ data BiometricAccuracyDescriptor = BiometricAccuracyDescriptor
     blockSlowdown :: Maybe IDL.UnsignedShort
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding BiometricAccuracyDescriptor
+
+instance Aeson.FromJSON BiometricAccuracyDescriptor where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON BiometricAccuracyDescriptor where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#patternaccuracydescriptor-dictionary)
 data PatternAccuracyDescriptor = PatternAccuracyDescriptor
@@ -84,7 +94,12 @@ data PatternAccuracyDescriptor = PatternAccuracyDescriptor
     blockSlowdown :: Maybe IDL.UnsignedShort
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding PatternAccuracyDescriptor
+
+instance Aeson.FromJSON PatternAccuracyDescriptor where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON PatternAccuracyDescriptor where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#verificationmethoddescriptor-dictionary)
 data VerificationMethodDescriptor = VerificationMethodDescriptor
@@ -98,7 +113,12 @@ data VerificationMethodDescriptor = VerificationMethodDescriptor
     paDesc :: Maybe PatternAccuracyDescriptor
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding VerificationMethodDescriptor
+
+instance Aeson.FromJSON VerificationMethodDescriptor where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON VerificationMethodDescriptor where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#verificationmethodandcombinations-typedef)
 newtype VerificationMethodANDCombinations = VerificationMethodANDCombinations (NonEmpty VerificationMethodDescriptor)
@@ -115,7 +135,12 @@ data RgbPaletteEntry = RgbPaletteEntry
     b :: IDL.UnsignedShort
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding RgbPaletteEntry
+
+instance Aeson.FromJSON RgbPaletteEntry where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON RgbPaletteEntry where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#displaypngcharacteristicsdescriptor-dictionary)
 data DisplayPNGCharacteristicsDescriptor = DisplayPNGCharacteristicsDescriptor
@@ -137,7 +162,12 @@ data DisplayPNGCharacteristicsDescriptor = DisplayPNGCharacteristicsDescriptor
     plte :: Maybe (NonEmpty RgbPaletteEntry)
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding DisplayPNGCharacteristicsDescriptor
+
+instance Aeson.FromJSON DisplayPNGCharacteristicsDescriptor where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON DisplayPNGCharacteristicsDescriptor where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#ecdaatrustanchor-dictionary)
 data EcdaaTrustAnchor = EcdaaTrustAnchor
@@ -155,7 +185,12 @@ data EcdaaTrustAnchor = EcdaaTrustAnchor
     litG1Curve :: IDL.DOMString
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding EcdaaTrustAnchor
+
+instance Aeson.FromJSON EcdaaTrustAnchor where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON EcdaaTrustAnchor where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#extensiondescriptor-dictionary)
 data ExtensionDescriptor = ExtensionDescriptor
@@ -169,7 +204,12 @@ data ExtensionDescriptor = ExtensionDescriptor
     fail_if_unknown :: IDL.Boolean
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding ExtensionDescriptor
+
+instance Aeson.FromJSON ExtensionDescriptor where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON ExtensionDescriptor where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#alternativedescriptions-dictionary)
 -- TODO: Replace Text with
@@ -253,7 +293,12 @@ data MetadataStatement = MetadataStatement
     authenticatorGetInfo :: Maybe AuthenticatorGetInfo
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding MetadataStatement
+
+instance Aeson.FromJSON MetadataStatement where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON MetadataStatement where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | Possible FIDO protocol families for 'protocolFamily'
 data ProtocolFamily
@@ -261,4 +306,9 @@ data ProtocolFamily
   | ProtocolFamilyU2F
   | ProtocolFamilyFIDO2
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via EnumJSONEncoding "ProtocolFamily" ProtocolFamily
+
+instance Aeson.FromJSON ProtocolFamily where
+  parseJSON = Aeson.genericParseJSON $ enumJSONEncodingOptions "ProtocolFamily"
+
+instance Aeson.ToJSON ProtocolFamily where
+  toJSON = Aeson.genericToJSON $ enumJSONEncodingOptions "ProtocolFamily"

--- a/src/Crypto/WebAuthn/Metadata/UAF.hs
+++ b/src/Crypto/WebAuthn/Metadata/UAF.hs
@@ -8,11 +8,10 @@ module Crypto.WebAuthn.Metadata.UAF
   )
 where
 
-import Crypto.WebAuthn.Internal.Utils (JSONEncoding)
+import Crypto.WebAuthn.Internal.Utils (jsonEncodingOptions)
 import qualified Crypto.WebAuthn.WebIDL as IDL
 import qualified Data.Aeson as Aeson
 import Data.Text (Text)
-import qualified Deriving.Aeson as Aeson
 import GHC.Generics (Generic)
 
 -- | [(spec)](https://fidoalliance.org/specs/fido-uaf-v1.2-ps-20201020/fido-uaf-protocol-v1.2-ps-20201020.html#authenticator-attestation-id-aaid-typedef)
@@ -35,4 +34,9 @@ data Version = Version
     minor :: IDL.UnsignedShort
   }
   deriving (Show, Eq, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding Version
+
+instance Aeson.FromJSON Version where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON Version where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions

--- a/src/Crypto/WebAuthn/Model/WebIDL/Internal/Binary/Decoding.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL/Internal/Binary/Decoding.hs
@@ -23,7 +23,7 @@ import Control.Monad (forM, unless)
 import Control.Monad.Except (MonadError (throwError))
 import Control.Monad.State (MonadState (get, put), StateT (runStateT))
 import qualified Crypto.Hash as Hash
-import Crypto.WebAuthn.Internal.Utils (CustomJSON (CustomJSON), JSONEncoding)
+import Crypto.WebAuthn.Internal.Utils (jsonEncodingOptions)
 import Crypto.WebAuthn.Model.Identifier (AAGUID (AAGUID))
 import qualified Crypto.WebAuthn.Model.Kinds as K
 import qualified Crypto.WebAuthn.Model.Types as M
@@ -216,8 +216,10 @@ data ClientDataJSON = ClientDataJSON
     -- tokenBinding :: Maybe TokenBinding
   }
   deriving (Generic)
-  -- Note: Encoding should NOT be derived via aeson. See the Encoding module instead
-  deriving (Aeson.FromJSON) via JSONEncoding ClientDataJSON
+
+-- Note: Encoding should NOT be derived via aeson. See the Encoding module instead
+instance Aeson.FromJSON ClientDataJSON where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
 
 -- | Decodes a 'M.CollectedClientData' from a 'BS.ByteString'. This is needed
 -- to parse the [clientDataJSON](https://www.w3.org/TR/webauthn-2/#dom-authenticatorresponse-clientdatajson)

--- a/src/Crypto/WebAuthn/Model/WebIDL/Types.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 -- | Stability: experimental
 -- This module models direct representations of JavaScript objects interacting with the
@@ -42,7 +41,7 @@ module Crypto.WebAuthn.Model.WebIDL.Types
   )
 where
 
-import Crypto.WebAuthn.Internal.Utils (CustomJSON (CustomJSON), JSONEncoding)
+import Crypto.WebAuthn.Internal.Utils (jsonEncodingOptions)
 import qualified Crypto.WebAuthn.WebIDL as IDL
 import qualified Data.Aeson as Aeson
 import Data.Map (Map)
@@ -71,7 +70,12 @@ data PublicKeyCredentialCreationOptions = PublicKeyCredentialCreationOptions
     extensions :: Maybe (Map Text Aeson.Value)
   }
   deriving (Eq, Show, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding PublicKeyCredentialCreationOptions
+
+instance Aeson.FromJSON PublicKeyCredentialCreationOptions where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON PublicKeyCredentialCreationOptions where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-rp-credential-params)
 data PublicKeyCredentialRpEntity = PublicKeyCredentialRpEntity
@@ -81,7 +85,12 @@ data PublicKeyCredentialRpEntity = PublicKeyCredentialRpEntity
     name :: IDL.DOMString
   }
   deriving (Eq, Show, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding PublicKeyCredentialRpEntity
+
+instance Aeson.FromJSON PublicKeyCredentialRpEntity where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON PublicKeyCredentialRpEntity where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-user-credential-params)
 data PublicKeyCredentialUserEntity = PublicKeyCredentialUserEntity
@@ -93,7 +102,12 @@ data PublicKeyCredentialUserEntity = PublicKeyCredentialUserEntity
     name :: IDL.DOMString
   }
   deriving (Eq, Show, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding PublicKeyCredentialUserEntity
+
+instance Aeson.FromJSON PublicKeyCredentialUserEntity where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON PublicKeyCredentialUserEntity where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-credential-params)
 data PublicKeyCredentialParameters = PublicKeyCredentialParameters
@@ -103,7 +117,12 @@ data PublicKeyCredentialParameters = PublicKeyCredentialParameters
     alg :: COSEAlgorithmIdentifier
   }
   deriving (Eq, Show, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding PublicKeyCredentialParameters
+
+instance Aeson.FromJSON PublicKeyCredentialParameters where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON PublicKeyCredentialParameters where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-alg-identifier)
 type COSEAlgorithmIdentifier = IDL.Long
@@ -118,7 +137,12 @@ data PublicKeyCredentialDescriptor = PublicKeyCredentialDescriptor
     transports :: Maybe [IDL.DOMString]
   }
   deriving (Eq, Show, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding PublicKeyCredentialDescriptor
+
+instance Aeson.FromJSON PublicKeyCredentialDescriptor where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON PublicKeyCredentialDescriptor where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictdef-authenticatorselectioncriteria)
 data AuthenticatorSelectionCriteria = AuthenticatorSelectionCriteria
@@ -132,7 +156,12 @@ data AuthenticatorSelectionCriteria = AuthenticatorSelectionCriteria
     userVerification :: Maybe IDL.DOMString
   }
   deriving (Eq, Show, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding AuthenticatorSelectionCriteria
+
+instance Aeson.FromJSON AuthenticatorSelectionCriteria where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON AuthenticatorSelectionCriteria where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictionary-assertion-options)
 data PublicKeyCredentialRequestOptions = PublicKeyCredentialRequestOptions
@@ -150,7 +179,12 @@ data PublicKeyCredentialRequestOptions = PublicKeyCredentialRequestOptions
     extensions :: Maybe (Map Text Aeson.Value)
   }
   deriving (Eq, Show, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding PublicKeyCredentialRequestOptions
+
+instance Aeson.FromJSON PublicKeyCredentialRequestOptions where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON PublicKeyCredentialRequestOptions where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-pkcredential)
 data PublicKeyCredential response = PublicKeyCredential
@@ -163,17 +197,11 @@ data PublicKeyCredential response = PublicKeyCredential
   }
   deriving (Eq, Show, Generic)
 
-deriving via
-  JSONEncoding (PublicKeyCredential response)
-  instance
-    Aeson.FromJSON response =>
-    Aeson.FromJSON (PublicKeyCredential response)
+instance Aeson.FromJSON response => Aeson.FromJSON (PublicKeyCredential response) where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
 
-deriving via
-  JSONEncoding (PublicKeyCredential response)
-  instance
-    Aeson.ToJSON response =>
-    Aeson.ToJSON (PublicKeyCredential response)
+instance Aeson.ToJSON response => Aeson.ToJSON (PublicKeyCredential response) where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-authenticatorattestationresponse)
 data AuthenticatorAttestationResponse = AuthenticatorAttestationResponse
@@ -187,7 +215,12 @@ data AuthenticatorAttestationResponse = AuthenticatorAttestationResponse
     transports :: Maybe [IDL.DOMString]
   }
   deriving (Eq, Show, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding AuthenticatorAttestationResponse
+
+instance Aeson.FromJSON AuthenticatorAttestationResponse where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON AuthenticatorAttestationResponse where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-authenticatorassertionresponse)
 data AuthenticatorAssertionResponse = AuthenticatorAssertionResponse
@@ -201,4 +234,9 @@ data AuthenticatorAssertionResponse = AuthenticatorAssertionResponse
     userHandle :: Maybe IDL.ArrayBuffer
   }
   deriving (Eq, Show, Generic)
-  deriving (Aeson.FromJSON, Aeson.ToJSON) via JSONEncoding AuthenticatorAssertionResponse
+
+instance Aeson.FromJSON AuthenticatorAssertionResponse where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON AuthenticatorAssertionResponse where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions

--- a/webauthn.cabal
+++ b/webauthn.cabal
@@ -66,9 +66,7 @@ library
   hs-source-dirs: src
   build-depends:
     base                  >= 4.14.3 && < 4.15,
-    -- deriving-aeson has compilation performance problems with aeson >= 2.0,
-    -- see https://github.com/fumieval/deriving-aeson/issues/16
-    aeson                 >= 1.4.7.1 && < 2.0,
+    aeson                 >= 1.4.7.1 && < 3.0,
     asn1-encoding         >= 0.9.6 && < 0.10,
     asn1-parse            >= 0.9.5 && < 0.10,
     asn1-types            >= 0.3.4 && < 0.4,
@@ -81,9 +79,9 @@ library
     cryptonite            >= 0.29 && < 0.30,
     deriving-aeson        >= 0.2.8 && < 0.3,
     file-embed            >= 0.0.15 && < 0.1,
-    hashable              >= 1.3.0 && < 1.4,
+    hashable              >= 1.3.0 && < 1.5,
     hourglass             >= 0.2.12 && < 0.3,
-    jose                  >= 0.8.5 && < 0.9,
+    jose                  >= 0.8.5 && < 0.10,
     lens                  >= 4.19.2 && < 4.20,
     memory                >= 0.15.0 && < 0.16,
     monad-time            >= 0.3.1 && < 0.4,
@@ -181,6 +179,7 @@ test-suite tests
     serialise,
     singletons,
     text,
+    unordered-containers,
     uuid,
     validation,
     webauthn,

--- a/webauthn.cabal
+++ b/webauthn.cabal
@@ -77,7 +77,6 @@ library
     cborg                 >= 0.2.6 && < 0.3,
     containers            >= 0.6.5 && < 0.7,
     cryptonite            >= 0.29 && < 0.30,
-    deriving-aeson        >= 0.2.8 && < 0.3,
     file-embed            >= 0.0.15 && < 0.1,
     hashable              >= 1.3.0 && < 1.5,
     hourglass             >= 0.2.12 && < 0.3,


### PR DESCRIPTION
Dropping the deriving-aeson dependency keeps compilation times low enough, while still allowing the upgrade to Aeson 2.

Some changes were made to ensure compatibility with Aeson 1.x and 2.x.

Dropping the dependency was due to: https://github.com/fumieval/deriving-aeson/issues/16

Compilation times:
- Master: 2m5.204s
- Aeson 2.0: 6m31.963s
- Aeson 2.0 without deriving-aeson: 2m2.934s