### PR TITLE
Further document VerificationError types, turn them into records

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 * [#115](https://github.com/tweag/webauthn/pull/115) Increase the upper bound
   of the supported Aeson versions, allowing the library to be built with Aeson
   2.0. Drop the deriving-aeson dependency.
+* [#117](https://github.com/tweag/webauthn/pull/117) Rename and expand
+  documentation for attestation statement format errors. Some unused errors
+  were removed.
 
 ### 0.1.1.0
 

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/AndroidSafetyNet.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/AndroidSafetyNet.hs
@@ -121,16 +121,18 @@ instance Aeson.ToJSON Statement where
 data VerificationError
   = -- | The receiced nonce was not set to the concatenation of the
     -- authenticator data and client data hash
-    VerificationErrorInvalidNonce
+    -- (first: nonce from the response, second: Base64 encoding of the SHA-256
+    -- hash of the concatenation of authenticatorData and clientDataHash)
+    NonceMismatch Text Text
   | -- | The response was created to far in the past
     -- (first: now, second: generated time)
-    VerificationErrorResponseTooOld HG.DateTime HG.DateTime
+    ResponseTooOld HG.DateTime HG.DateTime
   | -- | The response was created to far in the future
     -- (first: now, second: generated time)
-    VerificationErrorResponseInFuture HG.DateTime HG.DateTime
+    ResponseInFuture HG.DateTime HG.DateTime
   | -- | The integrity check failed based on the required integrity from the
     -- format
-    VerificationErrorFailedIntegrityCheck Integrity
+    IntegrityCheckFailed Integrity
   deriving (Show, Exception)
 
 androidHostName :: VerificationHostName
@@ -215,7 +217,8 @@ instance M.AttestationStatementFormat Format where
     let signedData = rawData <> BA.convert (M.unClientDataHash clientDataHash)
     let hashedData = Hash.hashWith Hash.SHA256 signedData
     let encodedData = decodeUtf8 . Base64.encode $ BA.convert hashedData
-    unless (nonce response == encodedData) . failure $ VerificationErrorInvalidNonce
+    let responseNonce = nonce response
+    unless (responseNonce == encodedData) . failure $ NonceMismatch responseNonce encodedData
 
     -- 4. Verify that the SafetyNet response actually came from the SafetyNet service by following the steps in the
     -- SafetyNet online documentation.
@@ -236,15 +239,15 @@ instance M.AttestationStatementFormat Format where
     -- NOTE: For WebAuthn, we need not care about the package name or the app's signing certificate. The Nonce as
     -- has already been dealt with.
     let generatedTime = HG.timeConvert $ timestampMs response
-    when ((generatedTime `HG.timeAdd` driftBackwardsTolerance) < now) $ failure $ VerificationErrorResponseTooOld now generatedTime
-    when (generatedTime > (now `HG.timeAdd` driftForwardsTolerance)) $ failure $ VerificationErrorResponseInFuture now generatedTime
+    when ((generatedTime `HG.timeAdd` driftBackwardsTolerance) < now) $ failure $ ResponseTooOld now generatedTime
+    when (generatedTime > (now `HG.timeAdd` driftForwardsTolerance)) $ failure $ ResponseInFuture now generatedTime
 
     let integrity = case (basicIntegrity response, ctsProfileMatch response) of
           (_, True) -> CTSProfileIntegrity
           (True, False) -> BasicIntegrity
           (False, False) -> NoIntegrity
     unless (integrity >= requiredIntegrity) $
-      failure $ VerificationErrorFailedIntegrityCheck integrity
+      failure $ IntegrityCheckFailed integrity
 
     -- 5. If successful, return implementation-specific values representing attestation type Basic and attestation trust
     -- path x5c.

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/FidoU2F.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/FidoU2F.hs
@@ -43,8 +43,12 @@ data VerificationError
   | -- | The credential public key is not an ECDSA key
     CredentialPublicKeyNotECDSA Cose.PublicKey
   | -- | The x and/or y coordinates of the credential public key don't have a length of 32 bytes
-    -- (first: length of received x coordinate, second: length of received y coordinate)
-    CoordinateSizeInvalid Int Int
+    CoordinateSizeInvalid
+      { -- | Actual length in bytes of the x coordinate
+        xLength :: Int,
+        -- | Actual length in bytes of the y coordinate
+        yLength :: Int
+      }
   | -- | The provided public key cannot validate the signature over the verification data
     SignatureInvalid X509.SignatureFailure
   deriving (Show, Exception)

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/FidoU2F.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/FidoU2F.hs
@@ -36,28 +36,17 @@ data Format = Format
 instance Show Format where
   show = Text.unpack . M.asfIdentifier
 
--- | Decoding errors specific to Fido U2F attestation
-data DecodingError
-  = -- | No Signature field was present
-    NoSig
-  | -- | No x5c certificate was present
-    NoX5C
-  | -- | Multiple x5c certificates were found where only one was expected
-    MultipleX5C
-  | -- | There was an error decoding the x5c certificate, string is the error resulted by the `Data.X509.decodeSignedCertificate` function
-    DecodingErrorX5C String
-  deriving (Show, Exception)
-
 -- | Verification errors specific to Fido U2F attestation
 data VerificationError
   = -- | The public key in the certificate was not an EC Key or the curve was not the p256 curve
-    InvalidCertificatePublicKey X509.PubKey
+    CertificatePublicKeyInvalid X509.PubKey
   | -- | The credential public key is not an ECDSA key
-    NonECDSACredentialPublicKey Cose.PublicKey
+    CredentialPublicKeyNotECDSA Cose.PublicKey
   | -- | The x and/or y coordinates of the credential public key don't have a length of 32 bytes
-    WrongCoordinateSize Int Int
+    -- (first: length of received x coordinate, second: length of received y coordinate)
+    CoordinateSizeInvalid Int Int
   | -- | The provided public key cannot validate the signature over the verification data
-    InvalidSignature X509.SignatureFailure
+    SignatureInvalid X509.SignatureFailure
   deriving (Show, Exception)
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-fido-u2f-attestation)
@@ -116,8 +105,8 @@ instance M.AttestationStatementFormat Format where
         X509.PubKeyEC pk ->
           case X509.ecPubKeyCurveName pk of
             Just SEC_p256r1 -> pure ()
-            _ -> failure $ InvalidCertificatePublicKey certPubKey
-        _ -> failure $ InvalidCertificatePublicKey certPubKey
+            _ -> failure $ CertificatePublicKeyInvalid certPubKey
+        _ -> failure $ CertificatePublicKeyInvalid certPubKey
 
       -- 3. Extract the claimed rpIdHash from authenticatorData, and the claimed
       -- credentialId and credentialPublicKey from authenticatorData.attestedCredentialData.
@@ -140,7 +129,7 @@ instance M.AttestationStatementFormat Format where
         Cose.PublicKeyECDSA {ecdsaX = xb, ecdsaY = yb} -> do
           let xlen = BS.length xb
               ylen = BS.length yb
-          unless (xlen == 32 && ylen == 32) $ failure $ WrongCoordinateSize xlen ylen
+          unless (xlen == 32 && ylen == 32) $ failure $ CoordinateSizeInvalid xlen ylen
 
           -- 4.c Let publicKeyU2F be the concatenation 0x04 || x || y.
           let publicKeyU2F = BS.singleton 0x04 <> xb <> yb
@@ -149,15 +138,20 @@ instance M.AttestationStatementFormat Format where
           -- clientDataHash || credentialId || publicKeyU2F) (see Section 4.3 of
           -- [FIDO-U2F-Message-Formats]).
           let credId = M.unCredentialId acdCredentialId
-              verificationData = BS.singleton 0x00 <> BA.convert (M.unRpIdHash adRpIdHash) <> BA.convert (M.unClientDataHash clientDataHash) <> credId <> publicKeyU2F
+              verificationData =
+                BS.singleton 0x00
+                  <> BA.convert (M.unRpIdHash adRpIdHash)
+                  <> BA.convert (M.unClientDataHash clientDataHash)
+                  <> credId
+                  <> publicKeyU2F
 
           -- 6. Verify the sig using verificationData and the certificate public key per
           -- section 4.1.4 of [SEC1] with SHA-256 as the hash function used in step two.
           case X509.verifySignature (X509.SignatureALG X509.HashSHA256 X509.PubKeyALG_EC) certPubKey verificationData sig of
             X509.SignaturePass -> pure ()
-            X509.SignatureFailed e -> failure $ InvalidSignature e
+            X509.SignatureFailed e -> failure $ SignatureInvalid e
           pure ()
-        key -> failure $ NonECDSACredentialPublicKey key
+        key -> failure $ CredentialPublicKeyNotECDSA key
 
       -- 7. Optionally, inspect x5c and consult externally provided knowledge to
       -- determine whether attStmt conveys a Basic or AttCA attestation.

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/Packed.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/Packed.hs
@@ -19,8 +19,8 @@ import qualified Crypto.WebAuthn.Cose.Algorithm as Cose
 import qualified Crypto.WebAuthn.Cose.Internal.Verify as Cose
 import qualified Crypto.WebAuthn.Cose.Key as Cose
 import Crypto.WebAuthn.Internal.Utils (IdFidoGenCeAAGUID (IdFidoGenCeAAGUID), failure)
+import Crypto.WebAuthn.Model (AAGUID)
 import qualified Crypto.WebAuthn.Model.Types as M
-import Data.ASN1.Error (ASN1Error)
 import qualified Data.ASN1.OID as OID
 import Data.Aeson (ToJSON, object, toJSON, (.=))
 import Data.Bifunctor (first)
@@ -63,25 +63,23 @@ instance ToJSON Statement where
 data VerificationError
   = -- | The Algorithm from the attestation format does not match the algorithm
     -- of the key in the credential data
-    VerificationErrorAlgorithmMismatch
+    -- (first: alg specified in the statement, second: credential public key
+    -- alg)
+    AlgorithmMismatch Cose.CoseSignAlg Cose.CoseSignAlg
   | -- | The statement key cannot verify the signature over the attested
     -- credential data and client data for self attestation
-    VerificationErrorInvalidSignature Text
+    InvalidSignature Text
   | -- | The statement certificate cannot verify the signature over the attested
     -- credential data and client data for nonself attestation
-    VerificationErrorVerificationFailure X509.SignatureFailure
+    VerificationFailure X509.SignatureFailure
   | -- | The certificate does not meet the requirements layed out in the
     -- webauthn specification
     -- https://www.w3.org/TR/webauthn-2/#sctn-packed-attestation-cert-requirements
-    VerificationErrorCertificateRequirementsUnmet
-  | -- | The (supposedly) ASN1 encoded certificate extension could not be
-    -- decoded
-    VerificationErrorASN1Error ASN1Error
-  | -- | The certificate extension does not contain a AAGUID
-    VerificationErrorCredentialAAGUIDMissing
+    CertificateRequirementsUnmet
   | -- | The AAGUID in the certificate extension does not match the AAGUID in
     -- the authenticator data
-    VerificationErrorCertificateAAGUIDMismatch
+    -- (first: from the certificate, second: from the credential data)
+    CertificateAAGUIDMismatch AAGUID AAGUID
   deriving (Show, Exception)
 
 instance M.AttestationStatementFormat Format where
@@ -136,13 +134,13 @@ instance M.AttestationStatementFormat Format where
           -- Validate that alg matches the algorithm of the credentialPublicKey in authenticatorData.
           let key = M.acdCredentialPublicKey credData
               signAlg = Cose.keySignAlg key
-          when (stmtAlg /= signAlg) $ failure VerificationErrorAlgorithmMismatch
+          when (stmtAlg /= signAlg) . failure $ AlgorithmMismatch stmtAlg signAlg
 
           -- Verify that sig is a valid signature over the concatenation of
           -- authenticatorData and clientDataHash using the credential public key with alg.
           case Cose.verify signAlg (Cose.fromCose key) signedData stmtSig of
             Right () -> pure ()
-            Left err -> failure $ VerificationErrorInvalidSignature err
+            Left err -> failure $ InvalidSignature err
 
           pure $ M.SomeAttestationType M.AttestationTypeSelf
 
@@ -154,7 +152,7 @@ instance M.AttestationStatementFormat Format where
           -- the attestation public key in attestnCert with the algorithm specified in alg.
           case X509.verifySignature (X509.SignatureALG X509.HashSHA256 X509.PubKeyALG_EC) pubKey signedData stmtSig of
             X509.SignaturePass -> pure ()
-            X509.SignatureFailed err -> failure $ VerificationErrorVerificationFailure err
+            X509.SignatureFailed err -> failure $ VerificationFailure err
 
           -- Verify that attestnCert meets the requirements in § 8.2.1 Packed Attestation Statement Certificate
           -- Requirements.
@@ -165,12 +163,12 @@ instance M.AttestationStatementFormat Format where
                 && hasDnElement X509.DnCommonName dnElements
                 && findDnElement X509.DnOrganizationUnit dnElements == Just "Authenticator Attestation"
             )
-            $ failure VerificationErrorCertificateRequirementsUnmet
+            $ failure CertificateRequirementsUnmet
 
           -- If attestnCert contains an extension with OID 1.3.6.1.4.1.45724.1.1.4 (id-fido-gen-ce-aaguid) verify that
           -- the value of this extension matches the aaguid in authenticatorData.
           let aaguid = M.acdAaguid credData
-          unless (aaguid == credAAGUID) $ failure VerificationErrorCertificateAAGUIDMismatch
+          unless (credAAGUID == aaguid) . failure $ CertificateAAGUIDMismatch credAAGUID aaguid
 
           pure $
             M.SomeAttestationType $

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/TPM.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/TPM.hs
@@ -11,6 +11,8 @@ module Crypto.WebAuthn.AttestationStatementFormat.TPM
   ( format,
     Format (..),
     VerificationError (..),
+    -- Exported because it's part of an error constructor
+    TPMAlgId (..),
   )
 where
 
@@ -24,6 +26,7 @@ import qualified Crypto.WebAuthn.Cose.Algorithm as Cose
 import qualified Crypto.WebAuthn.Cose.Internal.Verify as Cose
 import qualified Crypto.WebAuthn.Cose.Key as Cose
 import Crypto.WebAuthn.Internal.Utils (IdFidoGenCeAAGUID (IdFidoGenCeAAGUID), failure)
+import Crypto.WebAuthn.Model.Identifier (AAGUID)
 import qualified Crypto.WebAuthn.Model.Types as M
 import Data.ASN1.Error (ASN1Error)
 import Data.ASN1.OID (OID)
@@ -233,48 +236,49 @@ instance ToJSON Statement where
 data VerificationError
   = -- | The public key in the certificate is different from the on in the
     -- attested credential data
-    VerificationErrorCredentialKeyMismatch
-  | -- | The magic number in certInfo was not set to TPM_GENERATED_VALUE
-    VerificationErrorInvalidMagicNumber Word32
-  | -- | The type in certInfo was not set to TPM_ST_ATTEST_CERTIFY
-    VerificationErrorInvalidType Word16
+    -- (first: certificate, second: credential data)
+    PublicKeyMismatch Cose.PublicKey Cose.PublicKey
+  | -- | The magic number in certInfo was not set to TPM_GENERATED_VALUE (0xff544347)
+    MagicNumberInvalid Word32
+  | -- | The type in certInfo was not set to TPM_ST_ATTEST_CERTIFY (0x8017)
+    TypeInvalid Word16
   | -- | The algorithm specified in the nameAlg field is unsupported or is not
     -- a valid name algorithm
-    VerificationErrorInvalidNameAlgorithm
+    NameAlgorithmInvalid TPMAlgId
   | -- | The calulated name does not match the provided name.
     -- (first: expected, second: received)
-    VerificationErrorInvalidName BS.ByteString BS.ByteString
+    NameMismatch BS.ByteString BS.ByteString
   | -- | The public key in the certificate was invalid, either because the it
     -- had an unexpected algorithm, or because it was otherwise malformed
-    VerificationErrorInvalidPublicKey Text
-  | -- | The certificate didn't have the expected version-value
-    -- (first: expected, second: received)
-    VerificationErrorCertificateVersion Int Int
+    PublicKeyInvalid Text
+  | -- | The certificate didn't have the expected version-value (2)
+    CertificateVersionInvalid Int
   | -- | The Public key cannot verify the signature over the authenticatorData
     -- and the clientDataHash.
-    VerificationErrorVerificationFailure Text
+    VerificationFailure Text
   | -- | The subject field was not empty
-    VerificationErrorNonEmptySubjectField
+    SubjectFieldNotEmpty [(OID, X509.ASN1CharacterString)]
   | -- | The vendor was unknown
-    VerificationErrorUnknownVendor
+    VendorUnknown Text
   | -- | The Extended Key Usage did not contain the 2.23.133.8.3 OID
-    VerificationErrorExtKeyOIDMissing
+    ExtKeyOIDMissing
   | -- | The CA component of the basic constraints extension was set to True
-    VerificationErrorBasicConstraintsTrue
+    BasicConstraintsTrue
   | -- | The AAGUID in the certificate extension does not match the AAGUID in
     -- the authenticator data
-    VerificationErrorCertificateAAGUIDMismatch
+    -- (first: from the attested credential data, second: from the certificate extension)
+    CertificateAAGUIDMismatch AAGUID AAGUID
   | -- | The (supposedly) ASN1 encoded certificate extension could not be
     -- decoded
-    VerificationErrorASN1Error ASN1Error
+    ASN1Error ASN1Error
   | -- | The certificate extension does not contain a AAGUID
-    VerificationErrorCredentialAAGUIDMissing
+    CredentialAAGUIDMissing
   | -- | The desired algorithm does not have a known associated hash function
-    VerificationErrorUnknownHashFunction
+    HashFunctionUnknown
   | -- | The calculated hash over the attToBeSigned does not match the received
     -- hash
     -- (first: calculated, second: received)
-    VerificationErrorHashMismatch BS.ByteString BS.ByteString
+    HashMismatch BS.ByteString BS.ByteString
   deriving (Show, Exception)
 
 -- [(spec)](https://www.trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf)
@@ -499,7 +503,7 @@ instance M.AttestationStatementFormat Format where
       -- fields of pubArea is identical to the credentialPublicKey in the
       -- attestedCredentialData in authenticatorData.
       let pubKey = Cose.fromCose $ M.acdCredentialPublicKey adAttestedCredentialData
-      unless (pubKey == pubAreaKey) $ failure VerificationErrorCredentialKeyMismatch
+      unless (pubAreaKey == pubKey) . failure $ PublicKeyMismatch pubAreaKey pubKey
 
       -- 3. Concatenate authenticatorData and clientDataHash to form attToBeSigned.
       let attToBeSigned = adRawData <> BA.convert (M.unClientDataHash clientDataHash)
@@ -507,20 +511,20 @@ instance M.AttestationStatementFormat Format where
       -- 4. Validate that certInfo is valid:
       -- 4.1 Verify that magic is set to TPM_GENERATED_VALUE.
       let magic = tpmsaMagic certInfo
-      unless (magic == tpmGeneratedValue) . failure $ VerificationErrorInvalidMagicNumber magic
+      unless (magic == tpmGeneratedValue) . failure $ MagicNumberInvalid magic
 
       -- 4.2 Verify that type is set to TPM_ST_ATTEST_CERTIFY.
       let typ = tpmsaType certInfo
-      unless (typ == tpmStAttestCertify) . failure $ VerificationErrorInvalidType typ
+      unless (typ == tpmStAttestCertify) . failure $ TypeInvalid typ
 
       -- 4.3 Verify that extraData is set to the hash of attToBeSigned using
       -- the hash algorithm employed in "alg".
       case hashWithCorrectAlgorithm alg attToBeSigned of
         Just attHash -> do
           let extraData = tpmsaExtraData certInfo
-          unless (attHash == extraData) . failure $ VerificationErrorHashMismatch attHash extraData
+          unless (attHash == extraData) . failure $ HashMismatch attHash extraData
           pure ()
-        Nothing -> failure VerificationErrorUnknownHashFunction
+        Nothing -> failure HashFunctionUnknown
 
       -- 4.5 Verify that attested contains a TPMS_CERTIFY_INFO structure as
       -- specified in [TPMv2-Part2] section 10.12.3, whose name field contains
@@ -528,22 +532,22 @@ instance M.AttestationStatementFormat Format where
       -- nameAlg field of pubArea using the procedure specified in
       -- [TPMv2-Part1] section 16.
       let mPubAreaHash = case tpmtpNameAlg pubArea of
-            TPMAlgSHA1 -> Just $ BA.convert $ hashWith SHA1 pubAreaRaw
-            TPMAlgSHA256 -> Just $ BA.convert $ hashWith SHA256 pubAreaRaw
-            TPMAlgECC -> Nothing
-            TPMAlgRSA -> Nothing
+            TPMAlgSHA1 -> Right $ BA.convert $ hashWith SHA1 pubAreaRaw
+            TPMAlgSHA256 -> Right $ BA.convert $ hashWith SHA256 pubAreaRaw
+            TPMAlgECC -> Left TPMAlgECC
+            TPMAlgRSA -> Left TPMAlgRSA
 
       case mPubAreaHash of
-        Just pubAreaHash -> do
+        Right pubAreaHash -> do
           let pubName = LBS.toStrict $
                 Put.runPut $ do
                   Put.putWord16be (tpmtpNameAlgRaw pubArea)
                   Put.putByteString pubAreaHash
 
           let name = tpmsciName (tpmsaAttested certInfo)
-          unless (name == pubName) . failure $ VerificationErrorInvalidName pubName name
+          unless (name == pubName) . failure $ NameMismatch pubName name
           pure ()
-        Nothing -> failure VerificationErrorInvalidNameAlgorithm
+        Left alg -> failure $ NameAlgorithmInvalid alg
 
       -- 4.6 Verify that x5c is present
       -- NOTE: Done in decoding
@@ -560,8 +564,8 @@ instance M.AttestationStatementFormat Format where
       case Cose.fromX509 $ X509.certPubKey unsignedAikCert of
         Right certPubKey -> case Cose.verify alg certPubKey certInfoRaw sig of
           Right () -> pure ()
-          Left err -> failure $ VerificationErrorVerificationFailure err
-        Left err -> failure $ VerificationErrorInvalidPublicKey err
+          Left err -> failure $ VerificationFailure err
+        Left err -> failure $ PublicKeyInvalid err
 
       -- 4.9 Verify that aikCert meets the requirements in § 8.3.1 TPM Attestation
       -- Statement Certificate Requirements.
@@ -569,23 +573,25 @@ instance M.AttestationStatementFormat Format where
       -- 4.9.1 Version MUST be set to 3.
       -- Version ::= INTEGER { v1(0), v2(1), v3(2) }, see https://datatracker.ietf.org/doc/html/rfc5280.html#section-4.1
       let version = X509.certVersion unsignedAikCert
-      unless (version == 2) . failure $ VerificationErrorCertificateVersion 2 version
+      unless (version == 2) . failure $ CertificateVersionInvalid version
       -- 4.9.2. Subject field MUST be set to empty.
-      unless (null . X509.getDistinguishedElements $ X509.certSubjectDN unsignedAikCert) $ failure VerificationErrorNonEmptySubjectField
+      let subject = X509.getDistinguishedElements $ X509.certSubjectDN unsignedAikCert
+      unless (null subject) . failure $ SubjectFieldNotEmpty subject
       -- 4.9.3 The Subject Alternative Name extension MUST be set as defined in
       -- [TPMv2-EK-Profile] section 3.2.9.
       -- 4.9.3.1 The TPM manufacturer identifies the manufacturer of the TPM. This value MUST be the
       -- vendor ID defined in the TCG Vendor ID Registry[3]
-      unless (Set.member (tpmManufacturer subjectAlternativeName) tpmManufacturers) $ failure VerificationErrorUnknownVendor
+      let vendor = tpmManufacturer subjectAlternativeName
+      unless (Set.member vendor tpmManufacturers) . failure $ VendorUnknown vendor
 
       -- 4.9.4 The Extended Key Usage extension MUST contain the OID
       -- 2.23.133.8.3 ("joint-iso-itu-t(2) internationalorganizations(23) 133
       -- tcg-kp(8) tcg-kp-AIKCertificate(3)").
-      unless (X509.KeyUsagePurpose_Unknown [2, 23, 133, 8, 3] `elem` extendedKeyUsage) $ failure VerificationErrorExtKeyOIDMissing
+      unless (X509.KeyUsagePurpose_Unknown [2, 23, 133, 8, 3] `elem` extendedKeyUsage) $ failure ExtKeyOIDMissing
 
       -- 4.9.5 The Basic Constraints extension MUST have the CA component set
       -- to false.
-      when basicConstraintsCA $ failure VerificationErrorBasicConstraintsTrue
+      when basicConstraintsCA $ failure BasicConstraintsTrue
 
       -- 4.9.6 An Authority Information Access (AIA) extension with entry
       -- id-ad-ocsp and a CRL Distribution Point extension [RFC5280] are both
@@ -598,8 +604,10 @@ instance M.AttestationStatementFormat Format where
       -- If aikCert contains an extension with OID 1.3.6.1.4.1.45724.1.1.4
       -- (id-fido-gen-ce-aaguid) verify that the value of this extension
       -- matches the aaguid in authenticatorData.
+      let credentialAAGUID = M.acdAaguid adAttestedCredentialData
       case aaguidExt of
-        Just (IdFidoGenCeAAGUID aaguid) -> unless (M.acdAaguid adAttestedCredentialData == aaguid) $ failure VerificationErrorCertificateAAGUIDMismatch
+        Just (IdFidoGenCeAAGUID aaguid) -> do
+          unless (credentialAAGUID == aaguid) . failure $ CertificateAAGUIDMismatch credentialAAGUID aaguid
         Nothing -> pure ()
 
       pure $

--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -1114,7 +1114,14 @@ singletonAttestationStatementFormat someFormat@(SomeAttestationStatementFormat f
 
 -- | Attempt to find the desired attestation statement format in a map of
 -- supported formats. Can then be used to perform attestation.
-lookupAttestationStatementFormat :: Text -> SupportedAttestationStatementFormats -> Maybe SomeAttestationStatementFormat
+lookupAttestationStatementFormat ::
+  -- | The desired format, e.g. "android-safetynet" or "none"
+  Text ->
+  -- | The [attestation statement formats](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats)
+  -- that should be supported. The value of 'Crypto.WebAuthn.allSupportedFormats'
+  -- can be passed here, but additional or custom formats may also be used if needed.
+  SupportedAttestationStatementFormats ->
+  Maybe SomeAttestationStatementFormat
 lookupAttestationStatementFormat id (SupportedAttestationStatementFormats sasf) = sasf !? id
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#attestation-object)


### PR DESCRIPTION
Expand documentation of the `VerificationErrors` produced by the different
attestation statement formats, and turn any of them with an arity higher than 2
into a record. This allows for per-field documentation. Most errors were also
renamed to be more consistent and the `VerificationError`-prefix was dropped
where present.  Patternmatching on specific errors wherever used must be
changed to accomodate this change.  Additionally, missing documentation for the
arguments of the `lookupAttestationStatementFormat` function was added.