### PR TITLE
Small metadata type simplifications

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 ### Next version (0.3.0.0)
 
 * [#125](https://github.com/tweag/webauthn/pull/125) Some small metadata type
-  simplifications involving `msUpv`
+  simplifications involving `msUpv` and `SomeMetadataEntry`
 
 ### 0.2.0.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### Next version (0.3.0.0)
+
+* [#125](https://github.com/tweag/webauthn/pull/125) Some small metadata type
+  simplifications involving `msUpv`
+
 ### 0.2.0.0
 
 * [#115](https://github.com/tweag/webauthn/pull/115) Increase the upper bound

--- a/src/Crypto/WebAuthn/Metadata/Service/Decode.hs
+++ b/src/Crypto/WebAuthn/Metadata/Service/Decode.hs
@@ -55,19 +55,18 @@ decodeMetadataEntry ServiceIDL.MetadataBLOBPayloadEntry {..} = liftEitherMaybe $
       Left Nothing
     (Nothing, Just aaguid, Nothing) -> do
       -- This is a FIDO 2 entry
-      identifier <- first Just $ decodeAAGUID aaguid
+      meIdentifier <- first Just $ decodeAAGUID aaguid
       meMetadataStatement <- traverse decodeMetadataStatement metadataStatement
       meStatusReports <- first Just $ traverse decodeStatusReport statusReports
       meTimeOfLastStatusChange <- first Just $ decodeDate timeOfLastStatusChange
-      Right $ pure $ ServiceTypes.SomeMetadataEntry identifier ServiceTypes.MetadataEntry {..}
+      Right $ pure $ ServiceTypes.SomeMetadataEntry ServiceTypes.MetadataEntry {..}
     (Nothing, Nothing, Just attestationCertificateKeyIdentifiers) -> do
       -- This is a FIDO U2F entry
       identifiers <- first Just $ traverse decodeSubjectKeyIdentifier attestationCertificateKeyIdentifiers
       meMetadataStatement <- traverse decodeMetadataStatement metadataStatement
       meStatusReports <- first Just $ traverse decodeStatusReport statusReports
       meTimeOfLastStatusChange <- first Just $ decodeDate timeOfLastStatusChange
-      let entry = ServiceTypes.MetadataEntry {..}
-      Right $ fmap (`ServiceTypes.SomeMetadataEntry` entry) identifiers
+      Right $ fmap (\meIdentifier -> ServiceTypes.SomeMetadataEntry ServiceTypes.MetadataEntry {..}) identifiers
     (Nothing, Nothing, Nothing) ->
       Left $ Just "None of aaid, aaguid or attestationCertificateKeyIdentifiers are set for this entry"
     _ ->

--- a/src/Crypto/WebAuthn/Metadata/Service/Types.hs
+++ b/src/Crypto/WebAuthn/Metadata/Service/Types.hs
@@ -73,7 +73,9 @@ data MetadataPayload = MetadataPayload
 -- Same as 'StatementIDL.MetadataBLOBPayloadEntry', but fully decoded. This type
 -- is parametrized over the 'StatementIDL.ProtocolFamily' this metadata entry is for
 data MetadataEntry (p :: M.ProtocolKind) = MetadataEntry
-  { -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#dom-metadatablobpayloadentry-metadatastatement)
+  { -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#dom-metadatablobpayloadentry-aaguid) or [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#dom-metadatablobpayloadentry-attestationcertificatekeyidentifiers)
+    meIdentifier :: AuthenticatorIdentifier p,
+    -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#dom-metadatablobpayloadentry-metadatastatement)
     meMetadataStatement :: Maybe MetadataStatement,
     -- TODO: Implement this, currently not used in the blob however
     -- meBiometricStatusReports :: Maybe (NonEmpty BiometricStatusReport),
@@ -88,7 +90,7 @@ data MetadataEntry (p :: M.ProtocolKind) = MetadataEntry
   deriving (Eq, Show, Generic, ToJSON)
 
 -- | Same as 'MetadataEntry', but with its type parameter erased
-data SomeMetadataEntry = forall p. SingI p => SomeMetadataEntry (AuthenticatorIdentifier p) (MetadataEntry p)
+data SomeMetadataEntry = forall p. SingI p => SomeMetadataEntry (MetadataEntry p)
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#statusreport-dictionary)
 -- Same as 'StatementIDL.StatusReport', but fully decoded.

--- a/src/Crypto/WebAuthn/Metadata/Service/Types.hs
+++ b/src/Crypto/WebAuthn/Metadata/Service/Types.hs
@@ -73,8 +73,8 @@ data MetadataPayload = MetadataPayload
 -- Same as 'StatementIDL.MetadataBLOBPayloadEntry', but fully decoded. This type
 -- is parametrized over the 'StatementIDL.ProtocolFamily' this metadata entry is for
 data MetadataEntry (p :: M.ProtocolKind) = MetadataEntry
-  { -- [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#dom-metadatablobpayloadentry-metadatastatement)
-    meMetadataStatement :: Maybe (MetadataStatement p),
+  { -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-service-v3.0-ps-20210518.html#dom-metadatablobpayloadentry-metadatastatement)
+    meMetadataStatement :: Maybe MetadataStatement,
     -- TODO: Implement this, currently not used in the blob however
     -- meBiometricStatusReports :: Maybe (NonEmpty BiometricStatusReport),
 

--- a/src/Crypto/WebAuthn/Metadata/Statement/Types.hs
+++ b/src/Crypto/WebAuthn/Metadata/Statement/Types.hs
@@ -1,23 +1,17 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE StandaloneDeriving #-}
-
 -- | Stability: experimental
 -- This module contains additional Haskell-specific type definitions for the
 -- [FIDO Metadata Statement](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html)
 -- specification
 module Crypto.WebAuthn.Metadata.Statement.Types
   ( MetadataStatement (..),
-    ProtocolVersion (..),
     WebauthnAttestationType (..),
   )
 where
 
 import qualified Crypto.WebAuthn.Metadata.FidoRegistry as Registry
 import qualified Crypto.WebAuthn.Metadata.Statement.WebIDL as StatementIDL
-import qualified Crypto.WebAuthn.Model as M
-import Data.Aeson (ToJSON, toJSON)
+import qualified Crypto.WebAuthn.Metadata.UAF as UAF
+import Data.Aeson (ToJSON)
 import qualified Data.ByteString as BS
 import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
@@ -27,7 +21,7 @@ import GHC.Generics (Generic)
 import GHC.Word (Word16)
 
 -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#metadata-keys)
-data MetadataStatement (p :: M.ProtocolKind) = MetadataStatement
+data MetadataStatement = MetadataStatement
   { -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#dom-metadatastatement-legalheader)
     msLegalHeader :: Text,
     -- msAaid, msAaguid, attestationCertificateKeyIdentifiers: These fields are the key of the hashmaps in MetadataServiceRegistry
@@ -42,7 +36,7 @@ data MetadataStatement (p :: M.ProtocolKind) = MetadataStatement
     -- msSchema, this is always schema version 3
 
     -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#dom-metadatastatement-upv)
-    msUpv :: NonEmpty (ProtocolVersion p),
+    msUpv :: NonEmpty UAF.Version,
     -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#dom-metadatastatement-authenticationalgorithms)
     msAuthenticationAlgorithms :: NonEmpty Registry.AuthenticationAlgorithm,
     -- | [(spec)](https://fidoalliance.org/specs/mds/fido-metadata-statement-v3.0-ps-20210518.html#dom-metadatastatement-publickeyalgandencodings)
@@ -81,30 +75,6 @@ data MetadataStatement (p :: M.ProtocolKind) = MetadataStatement
     msAuthenticatorGetInfo :: Maybe StatementIDL.AuthenticatorGetInfo
   }
   deriving (Eq, Show, Generic, ToJSON)
-
--- | FIDO protocol versions, parametrized by the protocol family
-data ProtocolVersion (p :: M.ProtocolKind) where
-  -- | FIDO U2F 1.0
-  U2F1_0 :: ProtocolVersion 'M.FidoU2F
-  -- | FIDO U2F 1.1
-  U2F1_1 :: ProtocolVersion 'M.FidoU2F
-  -- | FIDO U2F 1.2
-  U2F1_2 :: ProtocolVersion 'M.FidoU2F
-  -- | FIDO 2, CTAP 2.0
-  CTAP2_0 :: ProtocolVersion 'M.Fido2
-  -- | FIDO 2, CTAP 2.1
-  CTAP2_1 :: ProtocolVersion 'M.Fido2
-
-deriving instance Eq (ProtocolVersion p)
-
-deriving instance Show (ProtocolVersion p)
-
-instance ToJSON (ProtocolVersion p) where
-  toJSON U2F1_0 = "U2F 1.0"
-  toJSON U2F1_1 = "U2F 1.1"
-  toJSON U2F1_2 = "U2F 1.2"
-  toJSON CTAP2_0 = "CTAP 2.0"
-  toJSON CTAP2_1 = "CTAP 2.1"
 
 -- | Values of 'Registry.AuthenticatorAttestationType' but limited to the ones possible with Webauthn, see https://www.w3.org/TR/webauthn-2/#sctn-attestation-types
 data WebauthnAttestationType

--- a/src/Crypto/WebAuthn/Metadata/Statement/WebIDL.hs
+++ b/src/Crypto/WebAuthn/Metadata/Statement/WebIDL.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 
 -- | Stability: experimental

--- a/src/Crypto/WebAuthn/Operation/Registration.hs
+++ b/src/Crypto/WebAuthn/Operation/Registration.hs
@@ -513,7 +513,7 @@ validateAttestationChain
 -- | Metadata statements can convey multiple attestation types.
 -- In such a case we choose to result in the Uncertain type.
 -- Otherwise, we results in the only one available.
-fixupVerifiableAttestationType :: M.VerifiableAttestationType -> Meta.MetadataStatement p -> M.VerifiableAttestationType
+fixupVerifiableAttestationType :: M.VerifiableAttestationType -> Meta.MetadataStatement -> M.VerifiableAttestationType
 fixupVerifiableAttestationType M.VerifiableAttestationTypeUncertain statement =
   case Meta.msAttestationTypes statement of
     -- If there are multiple types we can't know which one it is


### PR DESCRIPTION
I noticed some potential simplifications:
- Removes the type parameter from `MetadataStatement` by removing the `ProtocolVersion` type
- Cleans up some code by moving the `AuthenticatorIdentifier` from `SomeMetadataEntry` into `MetadataEntry` directly. Relates to #114 