### PR TITLE
Preparations for future extension support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+### Next release: 0.4.0.0
+
+* [#132](https://github.com/tweag/webauthn/pull/125) Preparations for future extension support:
+  - Renames `SupportedAttestationStatementFormats` to
+    `AttestationStatementFormatRegistry`
+  - Introduce the `WebAuthnRegistries` type, currently only consisting of an
+    `AttestationStatementFormatRegistry` and use it throughout instead of the
+    latter
+  - Replace `allSupportedFormats :: AttestationStatementFormatRegistry` with
+    `supportedRegistries :: WebAuthnRegistries`
+  - Make not only the registration response decoding function take a
+    `WebAuthnRegistries`, but also the authentication response decoding, so
+    that we later don't have to break compatibility when extensions are
+    implemented
+
 ### 0.3.0.0
 
 * [#125](https://github.com/tweag/webauthn/pull/125) Some small metadata type

--- a/server/src/Main.hs
+++ b/server/src/Main.hs
@@ -239,7 +239,7 @@ completeRegistration ::
 completeRegistration origin rpIdHash db pending registryVar = do
   credential <- Scotty.jsonData
   Scotty.liftAndCatchIO $ TIO.putStrLn $ "Raw register complete <= " <> jsonText credential
-  cred <- case WA.decodeCredentialRegistration WA.allSupportedFormats credential of
+  cred <- case WA.decodeCredentialRegistration WA.supportedRegistries credential of
     Left err -> do
       Scotty.liftAndCatchIO $ TIO.putStrLn $ "Register complete failed to decode raw request: " <> Text.pack (show err)
       fail $ show err

--- a/server/src/Main.hs
+++ b/server/src/Main.hs
@@ -345,7 +345,7 @@ completeLogin origin rpIdHash db pending = do
   Scotty.liftAndCatchIO $ TIO.putStrLn $ "Raw login complete <= " <> jsonText credential
 
   -- Decode credential
-  cred <- case WA.decodeCredentialAuthentication credential of
+  cred <- case WA.decodeCredentialAuthentication WA.supportedRegistries credential of
     Left err -> do
       Scotty.liftAndCatchIO $ TIO.putStrLn $ "Login complete failed to decode request: " <> Text.pack (show err)
       fail $ show err

--- a/src/Crypto/WebAuthn.hs
+++ b/src/Crypto/WebAuthn.hs
@@ -124,7 +124,7 @@ module Crypto.WebAuthn
     -- implementations of all standard attestation statement formats supported
     -- by this library. It can be passed to the 'decodeCredentialRegistration'
     -- to enable all these formats.
-    module Crypto.WebAuthn.AttestationStatementFormat,
+    module Crypto.WebAuthn.Registries,
 
     -- * Operations
 
@@ -158,7 +158,7 @@ module Crypto.WebAuthn
   )
 where
 
-import Crypto.WebAuthn.AttestationStatementFormat
 import Crypto.WebAuthn.Metadata
 import Crypto.WebAuthn.Model
 import Crypto.WebAuthn.Operation
+import Crypto.WebAuthn.Registries

--- a/src/Crypto/WebAuthn/AttestationStatementFormat.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat.hs
@@ -14,7 +14,7 @@ import qualified Crypto.WebAuthn.Model.Types as M
 -- | All supported [attestation statement formats](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats)
 -- of this library. This value can be passed to 'Crypto.WebAuthn.Model.WebIDL.Decoding.decodeCreatedPublicKeyCredential'.
 -- Since 'M.SupportedAttestationStatementFormats' is a 'Semigroup' the '<>' operator can be used to add additional formats if needed.
-allSupportedFormats :: M.SupportedAttestationStatementFormats
+allSupportedFormats :: M.AttestationStatementFormatRegistry
 allSupportedFormats =
   foldMap
     M.singletonAttestationStatementFormat

--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -76,7 +76,7 @@ module Crypto.WebAuthn.Model.Types
     SomeAttestationType (..),
     AttestationStatementFormat (..),
     SomeAttestationStatementFormat (..),
-    SupportedAttestationStatementFormats,
+    AttestationStatementFormatRegistry,
     singletonAttestationStatementFormat,
     lookupAttestationStatementFormat,
 
@@ -1129,16 +1129,16 @@ data SomeAttestationStatementFormat
 -- 'singletonAttestationStatementFormat' instead to construct it and
 -- 'lookupAttestationStatementFormat' to look up formats. '<>' can be used to
 -- combine multiple formats. 'mempty' can be used for not supporting any formats.
-newtype SupportedAttestationStatementFormats
+newtype AttestationStatementFormatRegistry
   = -- HashMap invariant: asfIdentifier (hm ! k) == k
-    SupportedAttestationStatementFormats (HashMap Text SomeAttestationStatementFormat)
+    AttestationStatementFormatRegistry (HashMap Text SomeAttestationStatementFormat)
   deriving newtype (Semigroup, Monoid)
 
--- | Creates a `SupportedAttestationStatementFormats`-Map containing a single
+-- | Creates a `AttestationStatementFormatRegistry`-Map containing a single
 -- supported format.
-singletonAttestationStatementFormat :: SomeAttestationStatementFormat -> SupportedAttestationStatementFormats
+singletonAttestationStatementFormat :: SomeAttestationStatementFormat -> AttestationStatementFormatRegistry
 singletonAttestationStatementFormat someFormat@(SomeAttestationStatementFormat format) =
-  SupportedAttestationStatementFormats $ HashMap.singleton (asfIdentifier format) someFormat
+  AttestationStatementFormatRegistry $ HashMap.singleton (asfIdentifier format) someFormat
 
 -- | Attempt to find the desired attestation statement format in a map of
 -- supported formats. Can then be used to perform attestation.
@@ -1148,9 +1148,9 @@ lookupAttestationStatementFormat ::
   -- | The [attestation statement formats](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats)
   -- that should be supported. The value of 'Crypto.WebAuthn.allSupportedFormats'
   -- can be passed here, but additional or custom formats may also be used if needed.
-  SupportedAttestationStatementFormats ->
+  AttestationStatementFormatRegistry ->
   Maybe SomeAttestationStatementFormat
-lookupAttestationStatementFormat id (SupportedAttestationStatementFormats sasf) = sasf !? id
+lookupAttestationStatementFormat id (AttestationStatementFormatRegistry sasf) = sasf !? id
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#attestation-object)
 data AttestationObject raw = forall a.

--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -79,6 +79,7 @@ module Crypto.WebAuthn.Model.Types
     AttestationStatementFormatRegistry,
     singletonAttestationStatementFormat,
     lookupAttestationStatementFormat,
+    WebAuthnRegistries (..),
 
     -- * Raw fields
     RawField (..),
@@ -1151,6 +1152,18 @@ lookupAttestationStatementFormat ::
   AttestationStatementFormatRegistry ->
   Maybe SomeAttestationStatementFormat
 lookupAttestationStatementFormat id (AttestationStatementFormatRegistry sasf) = sasf !? id
+
+-- A type for [IANA WebAuthn registries](https://www.iana.org/assignments/webauthn/webauthn.xhtml)
+-- of identifiers and their implementations. This currently only includes the
+-- [WebAuthn Attestation Statement Format Identifiers
+-- registry](https://www.iana.org/assignments/webauthn/webauthn.xhtml#webauthn-attestation-statement-format-ids),
+-- but in the future the [WebAuthn Extension Identifiers
+-- registry](https://www.iana.org/assignments/webauthn/webauthn.xhtml#webauthn-extension-ids)
+-- could be included as well.
+newtype WebAuthnRegistries = WebAuthnRegistries
+  { warAttestationStatementFormats :: AttestationStatementFormatRegistry
+  }
+  deriving newtype (Semigroup, Monoid)
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#attestation-object)
 data AttestationObject raw = forall a.

--- a/src/Crypto/WebAuthn/Model/WebIDL.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL.hs
@@ -22,7 +22,7 @@ import Control.Monad.Except (runExcept)
 import Control.Monad.Reader (runReaderT)
 import qualified Crypto.WebAuthn.Model.Kinds as K
 import qualified Crypto.WebAuthn.Model.Types as T
-import Crypto.WebAuthn.Model.WebIDL.Internal.Decoding (Decode (decode), DecodeCreated (decodeCreated))
+import Crypto.WebAuthn.Model.WebIDL.Internal.Decoding (Decode (decode))
 import Crypto.WebAuthn.Model.WebIDL.Internal.Encoding (Encode (encode))
 import qualified Crypto.WebAuthn.Model.WebIDL.Types as IDL
 import Data.Aeson (FromJSON, ToJSON)
@@ -61,13 +61,16 @@ newtype IDLCredentialRegistration = IDLCredentialRegistration
 -- function, to a @'T.Credential' 'K.Registration'@. This is the continuation
 -- of 'encodeCredentialOptionsRegistration'.
 decodeCredentialRegistration ::
-  -- | The [attestation statement formats](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats)
-  -- that should be supported. The value of 'Crypto.WebAuthn.allSupportedFormats'
-  -- can be passed here, but additional or custom formats may also be used if needed
+  -- | The [WebAuthn registries](https://www.iana.org/assignments/webauthn/webauthn.xhtml#webauthn-extension-ids)
+  -- that should be supported. This currently only includes
+  -- [attestation statement formats](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats).
+  -- The value of 'Crypto.WebAuthn.Registries.supportedRegistries' can be
+  -- passed here, but additional or custom registry values may also be used if
+  -- needed
   T.WebAuthnRegistries ->
   IDLCredentialRegistration ->
   Either Text (T.Credential 'K.Registration 'True)
-decodeCredentialRegistration registries (IDLCredentialRegistration value) = runExcept $ runReaderT (decodeCreated value) registries
+decodeCredentialRegistration registries (IDLCredentialRegistration value) = runExcept $ runReaderT (decode value) registries
 
 -- | Encodes a @'T.CredentialOptions' 'K.Authentication'@, which is needed for the
 -- [authentication ceremony](https://www.w3.org/TR/webauthn-2/#authentication). The
@@ -109,6 +112,13 @@ newtype IDLCredentialAuthentication = IDLCredentialAuthentication
 -- function, to a @'T.Credential' 'K.Authentication' True@. This is the continuation
 -- of 'encodeCredentialOptionsAuthentication'
 decodeCredentialAuthentication ::
+  -- | The [WebAuthn registries](https://www.iana.org/assignments/webauthn/webauthn.xhtml#webauthn-extension-ids)
+  -- that should be supported. This currently only includes
+  -- [attestation statement formats](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats),
+  -- which notably isn't used during authentication. The value of
+  -- 'Crypto.WebAuthn.Registries.supportedRegistries' can be passed here, but
+  -- additional or custom registry values may also be used if needed.
+  T.WebAuthnRegistries ->
   IDLCredentialAuthentication ->
   Either Text (T.Credential 'K.Authentication 'True)
-decodeCredentialAuthentication (IDLCredentialAuthentication value) = runExcept $ decode value
+decodeCredentialAuthentication registries (IDLCredentialAuthentication value) = runExcept $ runReaderT (decode value) registries

--- a/src/Crypto/WebAuthn/Model/WebIDL.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL.hs
@@ -18,6 +18,8 @@ module Crypto.WebAuthn.Model.WebIDL
   )
 where
 
+import Control.Monad.Except (runExcept)
+import Control.Monad.Reader (runReaderT)
 import qualified Crypto.WebAuthn.Model.Kinds as K
 import qualified Crypto.WebAuthn.Model.Types as T
 import Crypto.WebAuthn.Model.WebIDL.Internal.Decoding (Decode (decode), DecodeCreated (decodeCreated))
@@ -48,7 +50,7 @@ newtype IDLCredentialOptionsRegistration = IDLCredentialOptionsRegistration
 -- interface with the response being an
 -- [AuthenticatorAttestationResponse](https://www.w3.org/TR/webauthn-2/#authenticatorattestationresponse).
 newtype IDLCredentialRegistration = IDLCredentialRegistration
-  { unIDLCredentialRegistration :: IDL.PublicKeyCredential IDL.AuthenticatorAttestationResponse
+  { _unIDLCredentialRegistration :: IDL.PublicKeyCredential IDL.AuthenticatorAttestationResponse
   }
   deriving newtype (Show, Eq, FromJSON, ToJSON)
 
@@ -65,7 +67,7 @@ decodeCredentialRegistration ::
   T.WebAuthnRegistries ->
   IDLCredentialRegistration ->
   Either Text (T.Credential 'K.Registration 'True)
-decodeCredentialRegistration supportedFormats = decodeCreated supportedFormats . unIDLCredentialRegistration
+decodeCredentialRegistration registries (IDLCredentialRegistration value) = runExcept $ runReaderT (decodeCreated value) registries
 
 -- | Encodes a @'T.CredentialOptions' 'K.Authentication'@, which is needed for the
 -- [authentication ceremony](https://www.w3.org/TR/webauthn-2/#authentication). The
@@ -91,7 +93,7 @@ newtype IDLCredentialOptionsAuthentication = IDLCredentialOptionsAuthentication
 -- interface with the response being an
 -- [AuthenticatorAssertionResponse](https://www.w3.org/TR/webauthn-2/#authenticatorassertionresponse).
 newtype IDLCredentialAuthentication = IDLCredentialAuthentication
-  { unIDLCredentialAuthentication :: IDL.PublicKeyCredential IDL.AuthenticatorAssertionResponse
+  { _unIDLCredentialAuthentication :: IDL.PublicKeyCredential IDL.AuthenticatorAssertionResponse
   }
   deriving newtype (Show, Eq, FromJSON, ToJSON)
 
@@ -109,4 +111,4 @@ newtype IDLCredentialAuthentication = IDLCredentialAuthentication
 decodeCredentialAuthentication ::
   IDLCredentialAuthentication ->
   Either Text (T.Credential 'K.Authentication 'True)
-decodeCredentialAuthentication = decode . unIDLCredentialAuthentication
+decodeCredentialAuthentication (IDLCredentialAuthentication value) = runExcept $ decode value

--- a/src/Crypto/WebAuthn/Model/WebIDL.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL.hs
@@ -62,7 +62,7 @@ decodeCredentialRegistration ::
   -- | The [attestation statement formats](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats)
   -- that should be supported. The value of 'Crypto.WebAuthn.allSupportedFormats'
   -- can be passed here, but additional or custom formats may also be used if needed
-  T.AttestationStatementFormatRegistry ->
+  T.WebAuthnRegistries ->
   IDLCredentialRegistration ->
   Either Text (T.Credential 'K.Registration 'True)
 decodeCredentialRegistration supportedFormats = decodeCreated supportedFormats . unIDLCredentialRegistration

--- a/src/Crypto/WebAuthn/Model/WebIDL.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL.hs
@@ -62,7 +62,7 @@ decodeCredentialRegistration ::
   -- | The [attestation statement formats](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats)
   -- that should be supported. The value of 'Crypto.WebAuthn.allSupportedFormats'
   -- can be passed here, but additional or custom formats may also be used if needed
-  T.SupportedAttestationStatementFormats ->
+  T.AttestationStatementFormatRegistry ->
   IDLCredentialRegistration ->
   Either Text (T.Credential 'K.Registration 'True)
 decodeCredentialRegistration supportedFormats = decodeCreated supportedFormats . unIDLCredentialRegistration

--- a/src/Crypto/WebAuthn/Model/WebIDL/Internal/Binary/Decoding.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL/Internal/Binary/Decoding.hs
@@ -177,7 +177,7 @@ decodeAuthenticatorData strictBytes = runPartialBinaryDecoder strictBytes $ do
 -- structure This function takes a 'M.SupportedAttestationStatementFormats'
 -- argument to indicate which attestation statement formats are supported.
 -- structure
-decodeAttestationObject :: M.SupportedAttestationStatementFormats -> BS.ByteString -> Either Text (M.AttestationObject 'True)
+decodeAttestationObject :: M.AttestationStatementFormatRegistry -> BS.ByteString -> Either Text (M.AttestationObject 'True)
 decodeAttestationObject supportedFormats bytes = do
   (_consumed, result) <- runPartialBinaryDecoder bytes (runCBOR CBOR.decodeTerm)
   pairs <- case result of

--- a/src/Crypto/WebAuthn/Model/WebIDL/Internal/Decoding.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL/Internal/Decoding.hs
@@ -40,7 +40,7 @@ class Convert a => Decode a where
 -- 'M.SupportedAttestationStatementFormats' in order to allow decoding to depend
 -- on the supported attestation formats.
 class Convert a => DecodeCreated a where
-  decodeCreated :: M.AttestationStatementFormatRegistry -> IDL a -> Either Text a
+  decodeCreated :: M.WebAuthnRegistries -> IDL a -> Either Text a
 
 instance Decode a => Decode (Maybe a) where
   decode Nothing = pure Nothing
@@ -226,8 +226,8 @@ instance Decode (M.CredentialOptions 'K.Authentication) where
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-generating-an-attestation-object)
 instance DecodeCreated (M.AttestationObject 'True) where
-  decodeCreated supportedFormats (IDL.URLEncodedBase64 bytes) =
-    B.decodeAttestationObject supportedFormats bytes
+  decodeCreated registries (IDL.URLEncodedBase64 bytes) =
+    B.decodeAttestationObject (M.warAttestationStatementFormats registries) bytes
 
 instance DecodeCreated (M.AuthenticatorResponse 'K.Registration 'True) where
   decodeCreated supportedFormats IDL.AuthenticatorAttestationResponse {..} = do

--- a/src/Crypto/WebAuthn/Model/WebIDL/Internal/Decoding.hs
+++ b/src/Crypto/WebAuthn/Model/WebIDL/Internal/Decoding.hs
@@ -40,7 +40,7 @@ class Convert a => Decode a where
 -- 'M.SupportedAttestationStatementFormats' in order to allow decoding to depend
 -- on the supported attestation formats.
 class Convert a => DecodeCreated a where
-  decodeCreated :: M.SupportedAttestationStatementFormats -> IDL a -> Either Text a
+  decodeCreated :: M.AttestationStatementFormatRegistry -> IDL a -> Either Text a
 
 instance Decode a => Decode (Maybe a) where
   decode Nothing = pure Nothing

--- a/src/Crypto/WebAuthn/Registries.hs
+++ b/src/Crypto/WebAuthn/Registries.hs
@@ -1,6 +1,6 @@
 -- | Stability: experimental
 -- This module exports all supported [attestation statement format](https://www.w3.org/TR/webauthn-2/#attestation-statement-format)s by this library.
-module Crypto.WebAuthn.AttestationStatementFormat (allSupportedFormats) where
+module Crypto.WebAuthn.Registries (supportedRegistries) where
 
 import qualified Crypto.WebAuthn.AttestationStatementFormat.AndroidKey as AndroidKey
 import qualified Crypto.WebAuthn.AttestationStatementFormat.AndroidSafetyNet as AndroidSafetyNet
@@ -14,15 +14,18 @@ import qualified Crypto.WebAuthn.Model.Types as M
 -- | All supported [attestation statement formats](https://www.w3.org/TR/webauthn-2/#sctn-attestation-formats)
 -- of this library. This value can be passed to 'Crypto.WebAuthn.Model.WebIDL.Decoding.decodeCreatedPublicKeyCredential'.
 -- Since 'M.SupportedAttestationStatementFormats' is a 'Semigroup' the '<>' operator can be used to add additional formats if needed.
-allSupportedFormats :: M.AttestationStatementFormatRegistry
-allSupportedFormats =
-  foldMap
-    M.singletonAttestationStatementFormat
-    [ None.format,
-      Packed.format,
-      AndroidKey.format,
-      AndroidSafetyNet.format,
-      FidoU2F.format,
-      Apple.format,
-      TPM.format
-    ]
+supportedRegistries :: M.WebAuthnRegistries
+supportedRegistries =
+  M.WebAuthnRegistries
+    { M.warAttestationStatementFormats =
+        foldMap
+          M.singletonAttestationStatementFormat
+          [ None.format,
+            Packed.format,
+            AndroidKey.format,
+            AndroidSafetyNet.format,
+            FidoU2F.format,
+            Apple.format,
+            TPM.format
+          ]
+    }

--- a/tests/Encoding.hs
+++ b/tests/Encoding.hs
@@ -6,7 +6,7 @@ import Control.Monad.Except (runExcept)
 import Control.Monad.Reader (runReaderT)
 import qualified Crypto.WebAuthn.Model as M
 import Crypto.WebAuthn.Model.WebIDL.Internal.Binary.Encoding (encodeRawCredential)
-import Crypto.WebAuthn.Model.WebIDL.Internal.Decoding (Decode (decode), DecodeCreated (decodeCreated))
+import Crypto.WebAuthn.Model.WebIDL.Internal.Decoding (Decode (decode))
 import Crypto.WebAuthn.Model.WebIDL.Internal.Encoding (Encode (encode))
 import Crypto.WebAuthn.Registries (supportedRegistries)
 import Spec.Types ()
@@ -27,14 +27,14 @@ spec = do
 prop_creationOptionsRoundtrip :: M.CredentialOptions 'M.Registration -> Expectation
 prop_creationOptionsRoundtrip options = do
   let encoded = encode options
-  case runExcept $ decode encoded of
+  case runExcept $ runReaderT (decode encoded) supportedRegistries of
     Right decoded -> decoded `shouldBe` options
     Left err -> expectationFailure $ show err
 
 prop_requestOptionsRoundtrip :: M.CredentialOptions 'M.Authentication -> Expectation
 prop_requestOptionsRoundtrip options = do
   let encoded = encode options
-  case runExcept $ decode encoded of
+  case runExcept $ runReaderT (decode encoded) supportedRegistries of
     Right decoded -> decoded `shouldBe` options
     Left err -> expectationFailure $ show err
 
@@ -42,7 +42,7 @@ prop_createdCredentialRoundtrip :: M.Credential 'M.Registration 'False -> Expect
 prop_createdCredentialRoundtrip options = do
   let withRaw = encodeRawCredential options
       encoded = encode withRaw
-  case runExcept $ runReaderT (decodeCreated encoded) supportedRegistries of
+  case runExcept $ runReaderT (decode encoded) supportedRegistries of
     Right decoded -> do
       decoded `shouldBe` withRaw
     Left err -> expectationFailure $ show err
@@ -51,7 +51,7 @@ prop_requestedCredentialRoundtrip :: M.Credential 'M.Authentication 'False -> Ex
 prop_requestedCredentialRoundtrip options = do
   let withRaw = encodeRawCredential options
       encoded = encode withRaw
-  case runExcept $ decode encoded of
+  case runExcept $ runReaderT (decode encoded) supportedRegistries of
     Right decoded -> do
       decoded `shouldBe` withRaw
     Left err -> expectationFailure $ show err

--- a/tests/Encoding.hs
+++ b/tests/Encoding.hs
@@ -2,11 +2,11 @@
 
 module Encoding (spec) where
 
-import Crypto.WebAuthn.AttestationStatementFormat (allSupportedFormats)
 import qualified Crypto.WebAuthn.Model as M
 import Crypto.WebAuthn.Model.WebIDL.Internal.Binary.Encoding (encodeRawCredential)
 import Crypto.WebAuthn.Model.WebIDL.Internal.Decoding (Decode (decode), DecodeCreated (decodeCreated))
 import Crypto.WebAuthn.Model.WebIDL.Internal.Encoding (Encode (encode))
+import Crypto.WebAuthn.Registries (supportedRegistries)
 import Spec.Types ()
 import Test.Hspec (Expectation, SpecWith, describe, expectationFailure, shouldBe)
 import Test.Hspec.QuickCheck (prop)
@@ -40,7 +40,7 @@ prop_createdCredentialRoundtrip :: M.Credential 'M.Registration 'False -> Expect
 prop_createdCredentialRoundtrip options = do
   let withRaw = encodeRawCredential options
       encoded = encode withRaw
-  case decodeCreated allSupportedFormats encoded of
+  case decodeCreated supportedRegistries encoded of
     Right decoded -> do
       decoded `shouldBe` withRaw
     Left err -> expectationFailure $ show err

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -140,7 +140,7 @@ main = Hspec.hspec $ do
         registerResult `shouldSatisfy` isExpectedAttestationResponse pkCredential options False
         let Right O.RegistrationResult {O.rrEntry = credentialEntry} = registerResult
         loginReq <-
-          either (error . show) id . M.decodeCredentialAuthentication
+          either (error . show) id . M.decodeCredentialAuthentication supportedRegistries
             <$> decodeFile
               @M.IDLCredentialAuthentication
               "tests/responses/assertion/01-none.json"

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -10,12 +10,12 @@ module Main
 where
 
 import Crypto.Hash (hash)
-import Crypto.WebAuthn.AttestationStatementFormat (allSupportedFormats)
 import qualified Crypto.WebAuthn.Cose.Algorithm as Cose
 import qualified Crypto.WebAuthn.Metadata as Meta
 import qualified Crypto.WebAuthn.Metadata.Service.Types as Service
 import qualified Crypto.WebAuthn.Model as M
 import qualified Crypto.WebAuthn.Operation as O
+import Crypto.WebAuthn.Registries (supportedRegistries)
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
@@ -80,7 +80,7 @@ registryFromBlobFile = do
 registerTestFromFile :: FilePath -> M.Origin -> M.RpId -> Bool -> Service.MetadataServiceRegistry -> HG.DateTime -> IO ()
 registerTestFromFile fp origin rpId verifiable service now = do
   pkCredential <-
-    either (error . show) id . M.decodeCredentialRegistration allSupportedFormats
+    either (error . show) id . M.decodeCredentialRegistration supportedRegistries
       <$> decodeFile fp
   let options = defaultPublicKeyCredentialCreationOptions pkCredential
   let registerResult =
@@ -124,7 +124,7 @@ main = Hspec.hspec $ do
     it "tests whether the fixed register and login responses are matching" $
       do
         pkCredential <-
-          either (error . show) id . M.decodeCredentialRegistration allSupportedFormats
+          either (error . show) id . M.decodeCredentialRegistration supportedRegistries
             <$> decodeFile
               "tests/responses/attestation/01-none.json"
         let options = defaultPublicKeyCredentialCreationOptions pkCredential

--- a/webauthn.cabal
+++ b/webauthn.cabal
@@ -105,7 +105,6 @@ library
     x509-validation       >= 1.6.12 && < 1.7
   exposed-modules:
     Crypto.WebAuthn,
-    Crypto.WebAuthn.AttestationStatementFormat,
     Crypto.WebAuthn.AttestationStatementFormat.AndroidKey,
     Crypto.WebAuthn.AttestationStatementFormat.AndroidSafetyNet,
     Crypto.WebAuthn.AttestationStatementFormat.Apple,
@@ -145,6 +144,7 @@ library
     Crypto.WebAuthn.Model.WebIDL.Internal.Encoding,
     Crypto.WebAuthn.Model.WebIDL.Internal.Convert,
     Crypto.WebAuthn.Model.WebIDL.Types,
+    Crypto.WebAuthn.Registries,
     Crypto.WebAuthn.WebIDL
 
 test-suite tests


### PR DESCRIPTION
Makes sure that we won't have to break compatibility in the future when extensions are implemented, see #35

- Renames `SupportedAttestationStatementFormats` to `AttestationStatementFormatRegistry`
- Introduce the `WebAuthnRegistries` type, currently only consisting of an `AttestationStatementFormatRegistry` and use it throughout instead of the latter
- Replace `allSupportedFormats :: AttestationStatementFormatRegistry` with `supportedRegistries :: WebAuthnRegistries`
- Make not only the registration response decoding function take a `WebAuthnRegistries`, but also the authentication response decoding, so that we later don't have to break compatibility when extensions are implemented
