### PR TITLE
Support packed attestation format without a `x5c` CBOR key

### DIFF
--- a/tests/Emulation.hs
+++ b/tests/Emulation.hs
@@ -34,7 +34,7 @@ import Emulation.Client
     clientAttestation,
   )
 import Emulation.Client.Arbitrary ()
-import System.Hourglass (dateCurrent)
+import Spec.Util (predeterminedDateTime)
 import Test.Hspec (SpecWith, describe, it, shouldSatisfy)
 import Test.QuickCheck (property)
 
@@ -127,12 +127,10 @@ spec =
                 }
         -- Since our emulator only supports None attestation the registry can be left empty.
         let registry = mempty
-        -- The time could also be empty, but since we're in IO anyway, might as well just fetch it.
-        now <- dateCurrent
         -- We are not currently interested in client or authenticator fails, we
         -- only wish to test our relying party implementation and are thus only
         -- interested in its errors.
-        let Right (registerResult, authenticator', options) = runApp seed (register annotatedOrigin userAgentConformance authenticator registry now)
+        let Right (registerResult, authenticator', options) = runApp seed (register annotatedOrigin userAgentConformance authenticator registry predeterminedDateTime)
         -- Since we only do None attestation, we only care about the resulting entry
         let registerResult' = second O.rrEntry registerResult
         registerResult' `shouldSatisfy` validAttestationResult authenticator userAgentConformance options

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -33,22 +33,12 @@ import qualified Encoding
 import GHC.Stack (HasCallStack)
 import qualified MetadataSpec
 import qualified PublicKeySpec
-import Spec.Util (decodeFile)
+import Spec.Util (decodeFile, predeterminedDateTime, timeZero)
 import qualified System.Directory as Directory
 import System.FilePath ((</>))
-import System.Hourglass (dateCurrent)
 import Test.Hspec (Spec, describe, it, shouldSatisfy)
 import qualified Test.Hspec as Hspec
 import Test.QuickCheck.Instances.Text ()
-
--- | Attestation requires a specific time to be passed for the verification of the certificate chain.
--- For sake of reproducability we hardcode a time.
-predeterminedDateTime :: HG.DateTime
-predeterminedDateTime = HG.DateTime {dtDate = HG.Date {dateYear = 2021, dateMonth = HG.December, dateDay = 22}, dtTime = timeZero}
-
--- | For most uses of DateTime in these tests, the time of day isn't relevant. This definition allows easier construction of these DateTimes.
-timeZero :: HG.TimeOfDay
-timeZero = HG.TimeOfDay {todHour = HG.Hours 0, todMin = HG.Minutes 0, todSec = HG.Seconds 0, todNSec = HG.NanoSeconds 0}
 
 -- | Load all files in the given directory, and ensure that all of them can be
 -- decoded. The caller can pass in a function to run further checks on the
@@ -69,8 +59,7 @@ canDecodeAllToJSRepr path = do
 registryFromBlobFile :: IO Service.MetadataServiceRegistry
 registryFromBlobFile = do
   blobBytes <- BS.readFile "tests/golden-metadata/big/blob.jwt"
-  now <- dateCurrent
-  case Meta.metadataBlobToRegistry blobBytes now of
+  case Meta.metadataBlobToRegistry blobBytes predeterminedDateTime of
     Left err -> error $ Text.unpack err
     Right res -> pure res
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -212,10 +212,18 @@ main = Hspec.hspec $ do
         predeterminedDateTime
     it "tests whether the fixed packed register has a valid attestation" $
       registerTestFromFile
-        "tests/responses/attestation/packed-02.json"
+        "tests/responses/attestation/packed-03.json"
         "http://localhost:5000"
         "localhost"
         True
+        registry
+        predeterminedDateTime
+    it "regression test for #150" $
+      registerTestFromFile
+        "tests/responses/attestation/regression-150.json"
+        "https://webauthn.dev.tweag.io"
+        "webauthn.dev.tweag.io"
+        False
         registry
         predeterminedDateTime
     it "the response with transports information works" $
@@ -380,6 +388,10 @@ defaultPublicKeyCredentialCreationOptions c =
           M.CredentialParameters
             { M.cpTyp = M.CredentialTypePublicKey,
               M.cpAlg = Cose.CoseAlgorithmRS256
+            },
+          M.CredentialParameters
+            { cpTyp = M.CredentialTypePublicKey,
+              cpAlg = Cose.CoseAlgorithmEdDSA
             }
         ],
       M.corTimeout = Nothing,

--- a/tests/MetadataSpec.hs
+++ b/tests/MetadataSpec.hs
@@ -15,7 +15,7 @@ import qualified Data.Text as Text
 import Data.Text.Encoding (decodeUtf8)
 import qualified Data.X509 as X509
 import qualified Data.X509.CertificateStore as X509
-import System.Hourglass (dateCurrent)
+import Spec.Util (predeterminedDateTime)
 import Test.Hspec (SpecWith, describe, it, shouldBe, shouldSatisfy)
 import Test.Hspec.Expectations.Json (shouldBeUnorderedJson)
 
@@ -30,8 +30,7 @@ golden subdir = describe subdir $ do
         store = X509.makeCertificateStore [cert]
 
     blobBytes <- BS.readFile $ "tests/golden-metadata/" <> subdir <> "/blob.jwt"
-    now <- dateCurrent
-    let Right result = jwtToJson blobBytes (RootCertificate store origin) now
+    let Right result = jwtToJson blobBytes (RootCertificate store origin) predeterminedDateTime
 
     Just expectedPayload <- decodeFileStrict $ "tests/golden-metadata/" <> subdir <> "/payload.json"
 
@@ -61,5 +60,4 @@ spec = do
   describe "fidoAllianceRootCertificate" $ do
     it "can validate the payload" $ do
       blobBytes <- BS.readFile "tests/golden-metadata/big/blob.jwt"
-      now <- dateCurrent
-      jwtToJson blobBytes fidoAllianceRootCertificate now `shouldSatisfy` isRight
+      jwtToJson blobBytes fidoAllianceRootCertificate predeterminedDateTime `shouldSatisfy` isRight

--- a/tests/Spec/Util.hs
+++ b/tests/Spec/Util.hs
@@ -1,9 +1,10 @@
-module Spec.Util (decodeFile, runSeededMonadRandom) where
+module Spec.Util (decodeFile, runSeededMonadRandom, timeZero, predeterminedDateTime) where
 
 import qualified Crypto.Random as Random
 import Data.Aeson (FromJSON)
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString.Lazy as ByteString
+import qualified Data.Hourglass as HG
 
 decodeFile :: (FromJSON a, Show a) => FilePath -> IO a
 decodeFile filePath = do
@@ -16,3 +17,12 @@ runSeededMonadRandom :: Integer -> Random.MonadPseudoRandom Random.ChaChaDRG a -
 runSeededMonadRandom seed f = do
   let rng = Random.drgNewSeed $ Random.seedFromInteger seed
    in fst $ Random.withDRG rng f
+
+-- | Attestation requires a specific time to be passed for the verification of the certificate chain.
+-- For sake of reproducability we hardcode a time.
+predeterminedDateTime :: HG.DateTime
+predeterminedDateTime = HG.DateTime {HG.dtDate = HG.Date {HG.dateYear = 2021, HG.dateMonth = HG.December, HG.dateDay = 22}, HG.dtTime = timeZero}
+
+-- | For most uses of DateTime in these tests, the time of day isn't relevant. This definition allows easier construction of these DateTimes.
+timeZero :: HG.TimeOfDay
+timeZero = HG.TimeOfDay {HG.todHour = HG.Hours 0, HG.todMin = HG.Minutes 0, HG.todSec = HG.Seconds 0, HG.todNSec = HG.NanoSeconds 0}

--- a/tests/responses/attestation/regression-150.json
+++ b/tests/responses/attestation/regression-150.json
@@ -1,0 +1,13 @@
+{
+  "type": "public-key",
+  "id": "AdW2Vc7uD2urgMT9OMkyELoYSIxWvKoBY1gD5EQF9MlcOvHZUqqclf_Na5wTdzPneS0ms8bb3D9wu8QzelzRTjEqN4TazZKdKRxzGbozvBGawsNwjowK",
+  "rawId": "AdW2Vc7uD2urgMT9OMkyELoYSIxWvKoBY1gD5EQF9MlcOvHZUqqclf_Na5wTdzPneS0ms8bb3D9wu8QzelzRTjEqN4TazZKdKRxzGbozvBGawsNwjowK",
+  "response": {
+    "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiRk5MUFlnQUFBQUJOQTMzX253ZEIwbjJaWmZTNGEtRFYiLCJvcmlnaW4iOiJodHRwczovL3dlYmF1dGhuLmRldi50d2VhZy5pbyIsImNyb3NzT3JpZ2luIjpmYWxzZSwib3RoZXJfa2V5c19jYW5fYmVfYWRkZWRfaGVyZSI6ImRvIG5vdCBjb21wYXJlIGNsaWVudERhdGFKU09OIGFnYWluc3QgYSB0ZW1wbGF0ZS4gU2VlIGh0dHBzOi8vZ29vLmdsL3lhYlBleCJ9",
+    "attestationObject": "o2NmbXRmcGFja2VkZ2F0dFN0bXSiY2FsZyZjc2lnWEcwRQIhAIATxHdZC9pJA-RXLR-Gf0Kqnk8wk8YrmpEhff5D4dXuAiAH8rhgVstTbBNWSClMV7KZwtwTK9nmWPRAHOljZWH0gWhhdXRoRGF0YVjbz99AFunehK-NCfKrLtwZLiTxIgpzhkn0sc0Ib1Am45hFYs_Q663OAAI1vMYKZIsLJfHwVQMAVwHVtlXO7g9rq4DE_TjJMhC6GEiMVryqAWNYA-REBfTJXDrx2VKqnJX_zWucE3cz53ktJrPG29w_cLvEM3pc0U4xKjeE2s2SnSkccxm6M7wRmsLDcI6MCqUBAgMmIAEhWCC1PYYJ_C4KKBQ-10uWb8opsm9k7EfYnoETrdfsecI08iJYIPjQb8M6os-2zSb25VFANzAvniX1n5hiU_T7dyOhNS2a",
+    "transports": [
+      "internal"
+    ]
+  },
+  "clientExtensionResults": {}
+}


### PR DESCRIPTION
Should fix #150, but not tested yet.