### PR TITLE
Add support for the credProps extension

### DIFF
--- a/src/Crypto/WebAuthn/Encoding/Internal/WebAuthnJson.hs
+++ b/src/Crypto/WebAuthn/Encoding/Internal/WebAuthnJson.hs
@@ -219,7 +219,7 @@ instance Decode m Cose.CoseSignAlg where
   decode = liftEither . Cose.toCoseSignAlg
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-authentication-extensions-client-inputs)
-data AuthenticationExtensionsClientInputs = AuthenticationExtensionsClientInputs
+newtype AuthenticationExtensionsClientInputs = AuthenticationExtensionsClientInputs
   { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-authenticator-credential-properties-extension)
     credProps :: Maybe Bool
   }
@@ -249,7 +249,7 @@ instance Decode m T.AuthenticationExtensionsClientInputs where
     pure $ T.AuthenticationExtensionsClientInputs {..}
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictdef-credentialpropertiesoutput)
-data CredentialPropertiesOutput = CredentialPropertiesOutput
+newtype CredentialPropertiesOutput = CredentialPropertiesOutput
   { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-credentialpropertiesoutput-rk)
     rk :: Maybe Bool
   }
@@ -274,7 +274,7 @@ instance Decode m T.CredentialPropertiesOutput where
     pure $ T.CredentialPropertiesOutput {..}
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-authentication-extensions-client-outputs)
-data AuthenticationExtensionsClientOutputs = AuthenticationExtensionsClientOutputs
+newtype AuthenticationExtensionsClientOutputs = AuthenticationExtensionsClientOutputs
   { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-authenticator-credential-properties-extension)
     credProps :: Maybe CredentialPropertiesOutput
   }

--- a/src/Crypto/WebAuthn/Encoding/Internal/WebAuthnJson.hs
+++ b/src/Crypto/WebAuthn/Encoding/Internal/WebAuthnJson.hs
@@ -49,8 +49,6 @@ import qualified Data.ByteString.Base64.URL as Base64Url
 import Data.Coerce (Coercible, coerce)
 import Data.Int (Int32)
 import Data.Kind (Type)
-import Data.Map (Map)
-import qualified Data.Map as Map
 import Data.Singletons (SingI)
 import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
@@ -220,29 +218,88 @@ instance Encode Cose.CoseSignAlg where
 instance Decode m Cose.CoseSignAlg where
   decode = liftEither . Cose.toCoseSignAlg
 
-instance Encode T.AuthenticationExtensionsClientInputs where
-  type JSON T.AuthenticationExtensionsClientInputs = Map Text Aeson.Value
+-- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-authentication-extensions-client-inputs)
+data AuthenticationExtensionsClientInputs = AuthenticationExtensionsClientInputs
+  { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-authenticator-credential-properties-extension)
+    credProps :: Maybe Bool
+  }
+  deriving (Eq, Show, Generic)
 
+instance Aeson.FromJSON AuthenticationExtensionsClientInputs where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON AuthenticationExtensionsClientInputs where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
+
+instance Encode T.AuthenticationExtensionsClientInputs where
+  type JSON T.AuthenticationExtensionsClientInputs = AuthenticationExtensionsClientInputs
   -- TODO: Extensions are not implemented by this library, see the TODO in the
   -- module documentation of `Crypto.WebAuthn.Model` for more information.
-  encode T.AuthenticationExtensionsClientInputs {} = Map.empty
+  encode T.AuthenticationExtensionsClientInputs {..} =
+    AuthenticationExtensionsClientInputs
+      { credProps = aeciCredProps
+      }
 
 instance Decode m T.AuthenticationExtensionsClientInputs where
   -- TODO: Extensions are not implemented by this library, see the TODO in the
   -- module documentation of `Crypto.WebAuthn.Model` for more information.
-  decode _ = pure T.AuthenticationExtensionsClientInputs {}
+  decode AuthenticationExtensionsClientInputs {..} = do
+    let aeciCredProps = credProps
+    pure $ T.AuthenticationExtensionsClientInputs {..}
+
+-- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictdef-credentialpropertiesoutput)
+data CredentialPropertiesOutput = CredentialPropertiesOutput
+  { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-credentialpropertiesoutput-rk)
+    rk :: Maybe Bool
+  }
+  deriving (Eq, Show, Generic)
+
+instance Aeson.FromJSON CredentialPropertiesOutput where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON CredentialPropertiesOutput where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
+
+instance Encode T.CredentialPropertiesOutput where
+  type JSON T.CredentialPropertiesOutput = CredentialPropertiesOutput
+  encode T.CredentialPropertiesOutput {..} =
+    CredentialPropertiesOutput
+      { rk = cpoRk
+      }
+
+instance Decode m T.CredentialPropertiesOutput where
+  decode CredentialPropertiesOutput {..} = do
+    let cpoRk = rk
+    pure $ T.CredentialPropertiesOutput {..}
+
+-- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-authentication-extensions-client-outputs)
+data AuthenticationExtensionsClientOutputs = AuthenticationExtensionsClientOutputs
+  { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-authenticator-credential-properties-extension)
+    credProps :: Maybe CredentialPropertiesOutput
+  }
+  deriving (Eq, Show, Generic)
+
+instance Aeson.FromJSON AuthenticationExtensionsClientOutputs where
+  parseJSON = Aeson.genericParseJSON jsonEncodingOptions
+
+instance Aeson.ToJSON AuthenticationExtensionsClientOutputs where
+  toJSON = Aeson.genericToJSON jsonEncodingOptions
 
 instance Encode T.AuthenticationExtensionsClientOutputs where
-  type JSON T.AuthenticationExtensionsClientOutputs = Map Text Aeson.Value
-
+  type JSON T.AuthenticationExtensionsClientOutputs = AuthenticationExtensionsClientOutputs
   -- TODO: Extensions are not implemented by this library, see the TODO in the
   -- module documentation of `Crypto.WebAuthn.Model` for more information.
-  encode T.AuthenticationExtensionsClientOutputs {} = Map.empty
+  encode T.AuthenticationExtensionsClientOutputs {..} =
+    AuthenticationExtensionsClientOutputs
+      { credProps = encode aecoCredProps
+      }
 
 instance Decode m T.AuthenticationExtensionsClientOutputs where
   -- TODO: Extensions are not implemented by this library, see the TODO in the
   -- module documentation of `Crypto.WebAuthn.Model` for more information.
-  decode _ = pure T.AuthenticationExtensionsClientOutputs {}
+  decode AuthenticationExtensionsClientOutputs {..} = do
+    aecoCredProps <- decode credProps
+    pure $ T.AuthenticationExtensionsClientOutputs {..}
 
 instance SingI c => Encode (T.CollectedClientData (c :: K.CeremonyKind) 'True) where
   type JSON (T.CollectedClientData c 'True) = Base64UrlString
@@ -289,7 +346,7 @@ data PublicKeyCredentialCreationOptions = PublicKeyCredentialCreationOptions
     -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialcreationoptions-attestation)
     attestation :: Maybe Text,
     -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialcreationoptions-extensions)
-    extensions :: Maybe (Map Text Aeson.Value)
+    extensions :: Maybe AuthenticationExtensionsClientInputs
   }
   deriving (Eq, Show, Generic)
 
@@ -340,7 +397,7 @@ data PublicKeyCredentialRequestOptions = PublicKeyCredentialRequestOptions
     -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialrequestoptions-userverification)
     userVerification :: Maybe Text,
     -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialrequestoptions-extensions)
-    extensions :: Maybe (Map Text Aeson.Value)
+    extensions :: Maybe AuthenticationExtensionsClientInputs
   }
   deriving (Eq, Show, Generic)
 
@@ -544,7 +601,7 @@ data PublicKeyCredential response = PublicKeyCredential
     -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-publickeycredential-response)
     response :: response,
     -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-publickeycredential-getclientextensionresults)
-    clientExtensionResults :: Map Text Aeson.Value
+    clientExtensionResults :: AuthenticationExtensionsClientOutputs
   }
   deriving (Eq, Show, Generic)
 

--- a/src/Crypto/WebAuthn/Encoding/Internal/WebAuthnJson.hs
+++ b/src/Crypto/WebAuthn/Encoding/Internal/WebAuthnJson.hs
@@ -233,6 +233,7 @@ instance Aeson.ToJSON AuthenticationExtensionsClientInputs where
 
 instance Encode T.AuthenticationExtensionsClientInputs where
   type JSON T.AuthenticationExtensionsClientInputs = AuthenticationExtensionsClientInputs
+
   -- TODO: Extensions are not implemented by this library, see the TODO in the
   -- module documentation of `Crypto.WebAuthn.Model` for more information.
   encode T.AuthenticationExtensionsClientInputs {..} =
@@ -287,6 +288,7 @@ instance Aeson.ToJSON AuthenticationExtensionsClientOutputs where
 
 instance Encode T.AuthenticationExtensionsClientOutputs where
   type JSON T.AuthenticationExtensionsClientOutputs = AuthenticationExtensionsClientOutputs
+
   -- TODO: Extensions are not implemented by this library, see the TODO in the
   -- module documentation of `Crypto.WebAuthn.Model` for more information.
   encode T.AuthenticationExtensionsClientOutputs {..} =

--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -47,8 +47,8 @@
 -- #extensions#
 -- TODO:
 -- [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-extensions) This library
--- does not currently implement extensions. In order to fully comply with level
--- 2 of the webauthn spec extensions are required. At least, we wish the
+-- does not currently implement most extensions. In order to fully comply with
+-- level 2 of the webauthn spec extensions are required. At least, we wish the
 -- library to offer a typeclass implementable by relying parties to allow
 -- extensions in a scheme similar to the attestation statement formats.
 -- Ideally, we would implement all 8 extensions tracked by
@@ -87,6 +87,7 @@ module Crypto.WebAuthn.Model.Types
 
     -- * Extensions (unimplemented, see module documentation)
     AuthenticationExtensionsClientInputs (..),
+    CredentialPropertiesOutput (..),
     AuthenticationExtensionsClientOutputs (..),
     AuthenticatorExtensionOutputs (..),
 
@@ -659,26 +660,55 @@ newtype PublicKeyBytes = PublicKeyBytes {unPublicKeyBytes :: BS.ByteString}
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-authentication-extensions-client-inputs)
 -- This is a dictionary containing the [client extension input](https://www.w3.org/TR/webauthn-2/#client-extension-input)
 -- values for zero or more [WebAuthn Extensions](https://www.w3.org/TR/webauthn-2/#webauthn-extensions).
--- TODO: Extensions are not implemented by this library, see "Crypto.WebAuthn.Model.Types#extensions".
+-- TODO: Most extensions are not implemented by this library, see "Crypto.WebAuthn.Model.Types#extensions".
 data AuthenticationExtensionsClientInputs = AuthenticationExtensionsClientInputs
-  {
+  { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-authenticator-credential-properties-extension)
+    -- When true, indicates that that extension is requested by the [Relying Party](https://www.w3.org/TR/webauthn-2/#relying-party).
+    aeciCredProps :: Maybe Bool
   }
   deriving (Eq, Show)
 
 instance ToJSON AuthenticationExtensionsClientInputs where
-  toJSON _ = object []
+  toJSON AuthenticationExtensionsClientInputs {..} =
+    object
+      [ "aeciCredProps" .= aeciCredProps
+      ]
+
+-- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictdef-credentialpropertiesoutput)
+-- This is a dictionary containing the 
+data CredentialPropertiesOutput = CredentialPropertiesOutput
+  { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-credentialpropertiesoutput-rk)
+    -- The resident key credential property (i.e., client-side discoverable
+    -- credential property), indicating whether the `[PublicKeyCredential](https://www.w3.org/TR/webauthn-2/#publickeycredential)`
+    -- returned as a result of a registration ceremony is a client-side discoverable credential.
+    cpoRk :: Maybe Bool
+  }
+  deriving (Eq, Show)
+
+instance ToJSON CredentialPropertiesOutput where
+  toJSON CredentialPropertiesOutput {..} =
+    object
+      [ "cpoRk" .= cpoRk
+      ]
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-authentication-extensions-client-outputs)
 -- This is a dictionary containing the [client extension output](https://www.w3.org/TR/webauthn-2/#client-extension-output)
 -- values for zero or more [WebAuthn Extensions](https://www.w3.org/TR/webauthn-2/#webauthn-extensions).
--- TODO: Extensions are not implemented by this library, see "Crypto.WebAuthn.Model.Types#extensions".
+-- TODO: Most extensions are not implemented by this library, see "Crypto.WebAuthn.Model.Types#extensions".
 data AuthenticationExtensionsClientOutputs = AuthenticationExtensionsClientOutputs
-  {
+  { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-authenticator-credential-properties-extension)
+    -- When provided, indicates the value of the requireResidentKey parameter
+    -- that was used in the [invocation](https://www.w3.org/TR/webauthn-2/#CreateCred-InvokeAuthnrMakeCred)
+    -- of the `[authenticatorMakeCredential](https://www.w3.org/TR/webauthn-2/#authenticatormakecredential)` operation.
+    aecoCredProps :: Maybe CredentialPropertiesOutput
   }
   deriving (Eq, Show)
 
 instance ToJSON AuthenticationExtensionsClientOutputs where
-  toJSON _ = object []
+  toJSON AuthenticationExtensionsClientOutputs {..} =
+    object
+      [ "aecoCredProps" .= aecoCredProps
+      ]
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#authenticator-extension-output)
 data AuthenticatorExtensionOutputs = AuthenticatorExtensionOutputs

--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -661,7 +661,7 @@ newtype PublicKeyBytes = PublicKeyBytes {unPublicKeyBytes :: BS.ByteString}
 -- This is a dictionary containing the [client extension input](https://www.w3.org/TR/webauthn-2/#client-extension-input)
 -- values for zero or more [WebAuthn Extensions](https://www.w3.org/TR/webauthn-2/#webauthn-extensions).
 -- TODO: Most extensions are not implemented by this library, see "Crypto.WebAuthn.Model.Types#extensions".
-data AuthenticationExtensionsClientInputs = AuthenticationExtensionsClientInputs
+newtype AuthenticationExtensionsClientInputs = AuthenticationExtensionsClientInputs
   { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-authenticator-credential-properties-extension)
     -- When true, indicates that that extension is requested by the [Relying Party](https://www.w3.org/TR/webauthn-2/#relying-party).
     aeciCredProps :: Maybe Bool
@@ -676,7 +676,7 @@ instance ToJSON AuthenticationExtensionsClientInputs where
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictdef-credentialpropertiesoutput)
 -- This is a dictionary containing the client properties output.
-data CredentialPropertiesOutput = CredentialPropertiesOutput
+newtype CredentialPropertiesOutput = CredentialPropertiesOutput
   { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-credentialpropertiesoutput-rk)
     -- The resident key credential property (i.e., client-side discoverable
     -- credential property), indicating whether the `[PublicKeyCredential](https://www.w3.org/TR/webauthn-2/#publickeycredential)`
@@ -695,7 +695,7 @@ instance ToJSON CredentialPropertiesOutput where
 -- This is a dictionary containing the [client extension output](https://www.w3.org/TR/webauthn-2/#client-extension-output)
 -- values for zero or more [WebAuthn Extensions](https://www.w3.org/TR/webauthn-2/#webauthn-extensions).
 -- TODO: Most extensions are not implemented by this library, see "Crypto.WebAuthn.Model.Types#extensions".
-data AuthenticationExtensionsClientOutputs = AuthenticationExtensionsClientOutputs
+newtype AuthenticationExtensionsClientOutputs = AuthenticationExtensionsClientOutputs
   { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-authenticator-credential-properties-extension)
     -- When provided, indicates the value of the requireResidentKey parameter
     -- that was used in the [invocation](https://www.w3.org/TR/webauthn-2/#CreateCred-InvokeAuthnrMakeCred)

--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -675,7 +675,7 @@ instance ToJSON AuthenticationExtensionsClientInputs where
       ]
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictdef-credentialpropertiesoutput)
--- This is a dictionary containing the 
+-- This is a dictionary containing the client properties output.
 data CredentialPropertiesOutput = CredentialPropertiesOutput
   { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dom-credentialpropertiesoutput-rk)
     -- The resident key credential property (i.e., client-side discoverable

--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -667,12 +667,7 @@ newtype AuthenticationExtensionsClientInputs = AuthenticationExtensionsClientInp
     aeciCredProps :: Maybe Bool
   }
   deriving (Eq, Show)
-
-instance ToJSON AuthenticationExtensionsClientInputs where
-  toJSON AuthenticationExtensionsClientInputs {..} =
-    object
-      [ "aeciCredProps" .= aeciCredProps
-      ]
+  deriving newtype (ToJSON)
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#dictdef-credentialpropertiesoutput)
 -- This is a dictionary containing the client properties output.
@@ -684,12 +679,7 @@ newtype CredentialPropertiesOutput = CredentialPropertiesOutput
     cpoRk :: Maybe Bool
   }
   deriving (Eq, Show)
-
-instance ToJSON CredentialPropertiesOutput where
-  toJSON CredentialPropertiesOutput {..} =
-    object
-      [ "cpoRk" .= cpoRk
-      ]
+  deriving newtype (ToJSON)
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#iface-authentication-extensions-client-outputs)
 -- This is a dictionary containing the [client extension output](https://www.w3.org/TR/webauthn-2/#client-extension-output)
@@ -703,12 +693,7 @@ newtype AuthenticationExtensionsClientOutputs = AuthenticationExtensionsClientOu
     aecoCredProps :: Maybe CredentialPropertiesOutput
   }
   deriving (Eq, Show)
-
-instance ToJSON AuthenticationExtensionsClientOutputs where
-  toJSON AuthenticationExtensionsClientOutputs {..} =
-    object
-      [ "aecoCredProps" .= aecoCredProps
-      ]
+  deriving newtype (ToJSON)
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#authenticator-extension-output)
 data AuthenticatorExtensionOutputs = AuthenticatorExtensionOutputs

--- a/src/Crypto/WebAuthn/Operation/Authentication.hs
+++ b/src/Crypto/WebAuthn/Operation/Authentication.hs
@@ -232,7 +232,7 @@ verifyAuthenticationResponse origin rpIdHash midentifiedUser entry options crede
   -- initiated, verify that response.userHandle is present, and that the user
   -- identified by this value is the owner of credentialSource.
   let owner = ceUserHandle entry
-  
+
   -- According to the [(spec)](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialuserentity-id)
   -- The user handle MUST NOT be empty, though it MAY be null.
   -- For clarification see https://github.com/w3c/webauthn/issues/1722

--- a/tests/Emulation/Client.hs
+++ b/tests/Emulation/Client.hs
@@ -92,7 +92,7 @@ clientAttestation M.CredentialOptionsRegistration {..} AnnotatedOrigin {..} conf
                   M.arrAttestationObject = attestationObject,
                   M.arrTransports = []
                 },
-            M.cClientExtensionResults = M.AuthenticationExtensionsClientOutputs {}
+            M.cClientExtensionResults = M.AuthenticationExtensionsClientOutputs {aecoCredProps = Nothing}
           }
   pure (response, authenticator')
 
@@ -145,6 +145,6 @@ clientAssertion M.CredentialOptionsAuthentication {..} AnnotatedOrigin {..} conf
                   M.araSignature = M.AssertionSignature signature,
                   M.araUserHandle = userHandle
                 },
-            M.cClientExtensionResults = M.AuthenticationExtensionsClientOutputs {}
+            M.cClientExtensionResults = M.AuthenticationExtensionsClientOutputs {aecoCredProps = Nothing}
           }
   pure (response, authenticator')

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -145,7 +145,7 @@ main = Hspec.hspec $ do
                   M.Credential
                     { M.cIdentifier = O.ceCredentialId credentialEntry,
                       M.cResponse = cResponse,
-                      M.cClientExtensionResults = M.AuthenticationExtensionsClientOutputs {}
+                      M.cClientExtensionResults = M.AuthenticationExtensionsClientOutputs Nothing
                     }
         signInResult `shouldSatisfy` isRight
     it "tests whether the fixed register and login responses are matching with empty user handle" $
@@ -183,7 +183,7 @@ main = Hspec.hspec $ do
                   M.Credential
                     { M.cIdentifier = O.ceCredentialId credentialEntry,
                       M.cResponse = cResponse,
-                      M.cClientExtensionResults = M.AuthenticationExtensionsClientOutputs {}
+                      M.cClientExtensionResults = M.AuthenticationExtensionsClientOutputs Nothing
                     }
         signInResult `shouldSatisfy` isRight
   describe "Packed register" $ do

--- a/tests/PublicKeySpec.hs
+++ b/tests/PublicKeySpec.hs
@@ -7,8 +7,8 @@ where
 
 import Codec.Serialise.Properties (serialiseIdentity)
 import qualified Crypto.WebAuthn.Cose.Internal.Verify as Cose
-import qualified Crypto.WebAuthn.Cose.PublicKeyWithSignAlg as Cose
 import qualified Crypto.WebAuthn.Cose.PublicKey as Cose
+import qualified Crypto.WebAuthn.Cose.PublicKeyWithSignAlg as Cose
 import qualified Data.ByteString as BS
 import qualified Spec.Key as Key
 import Spec.Types ()

--- a/tests/Spec/Key.hs
+++ b/tests/Spec/Key.hs
@@ -19,10 +19,10 @@ import qualified Crypto.PubKey.Ed25519 as Ed25519
 import qualified Crypto.PubKey.RSA as RSA
 import qualified Crypto.PubKey.RSA.PKCS15 as RSA
 import Crypto.Random (MonadRandom)
-import qualified Crypto.WebAuthn.Cose.SignAlg as Cose
 import qualified Crypto.WebAuthn.Cose.Internal.Verify as Cose
-import qualified Crypto.WebAuthn.Cose.PublicKeyWithSignAlg as Cose
 import qualified Crypto.WebAuthn.Cose.PublicKey as Cose
+import qualified Crypto.WebAuthn.Cose.PublicKeyWithSignAlg as Cose
+import qualified Crypto.WebAuthn.Cose.SignAlg as Cose
 import qualified Data.ASN1.BinaryEncoding as ASN1
 import qualified Data.ASN1.Encoding as ASN1
 import qualified Data.ASN1.Prim as ASN1

--- a/tests/Spec/Types.hs
+++ b/tests/Spec/Types.hs
@@ -237,7 +237,7 @@ instance Arbitrary M.AuthenticatorSelectionCriteria where
       <*> arbitrary
 
 instance Arbitrary M.AuthenticationExtensionsClientInputs where
-  arbitrary = pure M.AuthenticationExtensionsClientInputs
+  arbitrary = M.AuthenticationExtensionsClientInputs <$> arbitrary
 
 instance Arbitrary (M.CredentialOptions 'M.Registration) where
   arbitrary =
@@ -262,8 +262,11 @@ instance Arbitrary (M.CredentialOptions 'M.Authentication) where
       <*> arbitrary
       <*> arbitrary
 
+instance Arbitrary M.CredentialPropertiesOutput where
+  arbitrary = M.CredentialPropertiesOutput <$> arbitrary
+
 instance Arbitrary M.AuthenticationExtensionsClientOutputs where
-  arbitrary = pure M.AuthenticationExtensionsClientOutputs
+  arbitrary = M.AuthenticationExtensionsClientOutputs <$> arbitrary
 
 instance Arbitrary (M.Credential 'M.Registration 'False) where
   arbitrary =

--- a/tests/responses/attestation/with-credprops.json
+++ b/tests/responses/attestation/with-credprops.json
@@ -1,0 +1,14 @@
+{
+  "type": "public-key",
+  "id": "KbeXjEj6HgsT_opADhRF46CXsWRR7Y8UndF03-f2sF8XRaimojYz950Mi2fN2S3DSDGyI5I3S_IZyGJbT85E6w",
+  "rawId": "KbeXjEj6HgsT_opADhRF46CXsWRR7Y8UndF03-f2sF8XRaimojYz950Mi2fN2S3DSDGyI5I3S_IZyGJbT85E6w",
+  "response": {
+    "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiaUxXVlU3bTJjWV9HQjR3SVN1Q3JKUSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MCIsImNyb3NzT3JpZ2luIjpmYWxzZX0",
+    "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjESZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2NFAAAABAAAAAAAAAAAAAAAAAAAAAAAQCm3l4xI-h4LE_6KQA4UReOgl7FkUe2PFJ3RdN_n9rBfF0WopqI2M_edDItnzdktw0gxsiOSN0vyGchiW0_OROulAQIDJiABIVggd6q1rL84dPlHqncwa69sOrqfs300BAp1lYv9pRlqIOgiWCA8sAhHyFxsiqy4HpSRVwIG5ZMcUU3iT8evBl7DHFh-9g"
+  },
+  "clientExtensionResults": {
+    "credProps": {
+      "rk": true
+    }
+  }
+}


### PR DESCRIPTION
Per https://github.com/tweag/webauthn/issues/35#issuecomment-1371564697 , this PR adds support for the `credProps` extension (ref https://www.w3.org/TR/webauthn-2/#sctn-authenticator-credential-properties-extension).

I added a test attestation to validate the parsing, and also used the test server locally to manually test that the feature (at least appears to be) working:

<img width="233" alt="Screenshot 2023-01-19 at 1 46 41 PM" src="https://user-images.githubusercontent.com/2091002/213806624-ca772cbe-52db-4ed2-b1d3-8c1eefb5c011.png">

This is my first time contributing to this repository (or any OSS Haskell repo), so please let me know if you need any changes.

Thank you!