### PR TITLE
Fix typo introduced by Origin -> Origins change

### DIFF
--- a/src/Crypto/WebAuthn/Operation/Authentication.hs
+++ b/src/Crypto/WebAuthn/Operation/Authentication.hs
@@ -75,11 +75,11 @@ data AuthenticationError
         -- | The challenge received from the client, part of the response
         aeReceivedChallenge :: M.Challenge
       }
-  | -- | The origin derived by the client does match the assumed origin
+  | -- | The origin derived by the client does match any of the assumed origins
     AuthenticationOriginMismatch
-      { -- | The origin explicitly passed to the `verifyAuthenticationResponse`
+      { -- | The origins explicitly passed to the `verifyAuthenticationResponse`
         -- response, set by the RP
-        aeExpectedOrigin :: NonEmpty M.Origin,
+        aeExpectedOrigins :: NonEmpty M.Origin,
         -- | The origin received from the client as part of the client data
         aeReceivedOrigin :: M.Origin
       }

--- a/src/Crypto/WebAuthn/Operation/Registration.hs
+++ b/src/Crypto/WebAuthn/Operation/Registration.hs
@@ -68,11 +68,11 @@ data RegistrationError
         -- | The challenge received from the client, part of the response
         reReceivedChallenge :: M.Challenge
       }
-  | -- | The returned origin does not match the relying party's origin
+  | -- | The returned origin does not match any of the the relying party's origins
     RegistrationOriginMismatch
-      { -- | The origin explicitly passed to the `verifyRegistrationResponse`
+      { -- | The origins explicitly passed to the `verifyRegistrationResponse`
         -- response, set by the RP
-        reExpectedOrigin :: NonEmpty M.Origin,
+        reExpectedOrigins :: NonEmpty M.Origin,
         -- | The origin received from the client as part of the client data
         reReceivedOrigin :: M.Origin
       }


### PR DESCRIPTION
The recent introduction of multiple accepted origins missed a few places where we still refer to a single Origin.