### PR TITLE
Add missing monotonicTime

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+### Next release: 0.10.1.0
+
+* [#187](https://github.com/tweag/webauthn/pull/187) Implement monotonicTime in MonadTime to resolve build-time warning
+
 ### 0.10.0.0
 
 * [#184](https://github.com/tweag/webauthn/pull/184) Pass a list of allowed origins instead of a single origin.

--- a/src/Crypto/WebAuthn/Internal/DateOrphans.hs
+++ b/src/Crypto/WebAuthn/Internal/DateOrphans.hs
@@ -21,7 +21,7 @@
 module Crypto.WebAuthn.Internal.DateOrphans () where
 
 import Control.Monad.Reader (ReaderT, asks)
-import Control.Monad.Time (MonadTime, currentTime)
+import Control.Monad.Time (MonadTime, currentTime, monotonicTime)
 import Data.Fixed (Fixed (MkFixed), HasResolution, Nano)
 import Data.Hourglass (Elapsed (Elapsed), ElapsedP (ElapsedP), NanoSeconds (NanoSeconds), Seconds (Seconds), Time, Timeable, timeConvert, timeFromElapsedP, timeGetElapsedP)
 import Data.Time (UTCTime, nominalDiffTimeToSeconds, secondsToNominalDiffTime)
@@ -45,3 +45,4 @@ instance (HasResolution a) => Timeable (Fixed a) where
 
 instance (Timeable t, Monad m) => MonadTime (ReaderT t m) where
   currentTime = asks timeConvert
+  monotonicTime = asks (realToFrac . timeGetElapsedP)

--- a/webauthn.cabal
+++ b/webauthn.cabal
@@ -90,7 +90,7 @@ library
     jose                    >= 0.11 && < 0.12,
     lens                    >= 4.18.1 && < 5.3,
     memory                  >= 0.15.0 && < 0.19,
-    monad-time              >= 0.3.1 && < 0.5,
+    monad-time              >= 0.4.0 && < 0.5,
     mtl                     >= 2.2.2 && < 2.4,
     serialise               >= 0.2.3 && < 0.3,
     singletons              >= 2.6 && < 3.2,


### PR DESCRIPTION
I got a warning about this when compiling.

It is added to the `MonadTime` class in `monad-time-0.4.0.0`. (A small downside of not having upper bounds.)