### PR TITLE
Remove partial field accessors throughout the project

### DIFF
--- a/src/Crypto/WebAuthn/AttestationStatementFormat/AndroidKey.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/AndroidKey.hs
@@ -178,44 +178,40 @@ data VerificationError
   = -- | The public key in the certificate is different from the on in the
     -- attested credential data
     PublicKeyMismatch
-      { -- | The public key part of the credential data
-        credentialDataPublicKey :: Cose.PublicKey,
-        -- | The public key extracted from the signed certificate
-        certificatePublicKey :: Cose.PublicKey
-      }
+      -- | The public key part of the credential data
+      Cose.PublicKey
+      -- | The public key extracted from the signed certificate
+      Cose.PublicKey
   | -- | The challenge field of the certificate extension does not match the
     -- clientDataHash
     -- (first: challenge from certificate extension, second: clientDataHash)
     HashMismatch
-      { -- | The challenge part of the
-        -- [@attestation-extension@](https://source.android.com/security/keystore/attestation#attestation-extension)
-        certificateChallenge :: Digest SHA256,
-        -- | The client data hash
-        clientDataHash :: Digest SHA256
-      }
+      -- | The challenge part of the
+      -- [@attestation-extension@](https://source.android.com/security/keystore/attestation#attestation-extension)
+      (Digest SHA256)
+      -- | The client data hash
+      (Digest SHA256)
   | -- | The "attestation" extension is scoped to all applications instead of just the RpId
     AndroidKeyAllApplicationsFieldFound
   | -- | The origin field(s) were not equal to KM_ORIGIN_GENERATED (0)
     -- (first: tee-enforced origin, second: software-enforced origin (if allowed by the specified Format))
     AndroidKeyOriginFieldInvalid
-      { -- | The origin enforced by the trusted execution environment
-        teeEnforcedOrigin :: Maybe Integer,
-        -- | The origin enforced by software. NOTE: This field is explicitly
-        -- set to `Nothing` if the `Format` specified `TeeEnforced` as the
-        -- `requiredTrustLevel`.
-        softwareEnforcedOrigin :: Maybe Integer
-      }
+      -- | The origin enforced by the trusted execution environment
+      (Maybe Integer)
+      -- | The origin enforced by software. NOTE: This field is explicitly
+      -- set to `Nothing` if the `Format` specified `TeeEnforced` as the
+      -- `requiredTrustLevel`.
+      (Maybe Integer)
   | -- | The purpose field(s) were not equal to the singleton set containing
     -- KM_PURPOSE_SIGN (2)
     -- (first: tee-enforced purpose, second: software-enforced purpose (if allowed by the specified Format))
     AndroidKeyPurposeFieldInvalid
-      { -- | The purpose enforced by the trusted execution environment
-        teeEnforcedPurpose :: Maybe (Set Integer),
-        -- | The purpose enforced by software. NOTE: This field is explicitly
-        -- set to `Nothing` if the `Format` specified `TeeEnforced` as the
-        -- `requiredTrustLevel`.
-        softwareEnforcedPurpose :: Maybe (Set Integer)
-      }
+      -- | The purpose enforced by the trusted execution environment
+      (Maybe (Set Integer))
+      -- | The purpose enforced by software. NOTE: This field is explicitly
+      -- set to `Nothing` if the `Format` specified `TeeEnforced` as the
+      -- `requiredTrustLevel`.
+      (Maybe (Set Integer))
   | -- | The Public key cannot verify the signature over the authenticatorData
     -- and the clientDataHash.
     VerificationFailure Text

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/AndroidSafetyNet.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/AndroidSafetyNet.hs
@@ -122,21 +122,19 @@ data VerificationError
   = -- | The receiced nonce was not set to the concatenation of the
     -- authenticator data and client data hash
     NonceMismatch
-      { -- | Nonce from the AndroidSafetyNet response
-        responseNonce :: Text,
-        -- | Base64 encoding of the SHA-256 hash of the concatenation of
-        -- authenticatorData and clientDataHash
-        calculatedNonce :: Text
-      }
+      -- | Nonce from the AndroidSafetyNet response
+      Text
+      -- | Base64 encoding of the SHA-256 hash of the concatenation of
+      -- authenticatorData and clientDataHash
+      Text
   | -- | The response was created to far in the past or future
     ResponseTimeInvalid
-      { -- | The UTC time minus the allowed drift specified in the `Format`.
-        lowerBound :: HG.DateTime,
-        -- | The UTC time plus the allowed drift specified in the `Format`.
-        upperBound :: HG.DateTime,
-        -- | The UTC time when the Android SafetyNet response was generated
-        generatedtime :: HG.DateTime
-      }
+      -- | The UTC time minus the allowed drift specified in the `Format`.
+      HG.DateTime
+      -- | The UTC time plus the allowed drift specified in the `Format`.
+      HG.DateTime
+      -- | The UTC time when the Android SafetyNet response was generated
+      HG.DateTime
   | -- | The integrity check failed based on the required integrity from the
     -- format
     IntegrityCheckFailed Integrity

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/Apple.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/Apple.hs
@@ -50,21 +50,19 @@ data VerificationError
   = -- | The nonce found in the certificate extension does not match the
     -- expected nonce
     NonceMismatch
-      { -- | The SHA256 hash of the concatenation of the @authenticatorData@
-        -- and @clientDataHash@
-        calculatedNonce :: Digest SHA256,
-        -- | The nonce from the Apple nonce certificate extension
-        -- (1.2.840.113635.100.8.2)
-        receivedNonce :: Digest SHA256
-      }
+      -- | The SHA256 hash of the concatenation of the @authenticatorData@
+      -- and @clientDataHash@
+      (Digest SHA256)
+      -- | The nonce from the Apple nonce certificate extension
+      -- (1.2.840.113635.100.8.2)
+      (Digest SHA256)
   | -- | The public Key found in the certificate does not match the
     -- credential's public key.
     PublicKeyMismatch
-      { -- | The public key part of the credential data
-        credentialDataPublicKey :: Cose.PublicKey,
-        -- | The public key extracted from the signed certificate
-        certificatePublicKey :: Cose.PublicKey
-      }
+      -- | The public key part of the credential data
+      Cose.PublicKey
+      -- | The public key extracted from the signed certificate
+      Cose.PublicKey
   deriving (Show, Exception)
 
 -- | [(spec)](https://www.w3.org/TR/webauthn-2/#sctn-apple-anonymous-attestation)

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/FidoU2F.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/FidoU2F.hs
@@ -47,11 +47,10 @@ data VerificationError
     CredentialPublicKeyNotCoseEC2 Cose.CosePublicKey
   | -- | The x and/or y coordinates of the credential public key are longer than 32 bytes
     CoordinateSizeInvalid
-      { -- | Actual length in bytes of the x coordinate
-        xLength :: Int,
-        -- | Actual length in bytes of the y coordinate
-        yLength :: Int
-      }
+      -- | Actual length in bytes of the x coordinate
+      Int
+      -- | Actual length in bytes of the y coordinate
+      Int
   | -- | The provided public key cannot validate the signature over the verification data
     SignatureInvalid X509.SignatureFailure
   deriving (Show, Exception)

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/Packed.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/Packed.hs
@@ -65,11 +65,10 @@ data VerificationError
   = -- | The Algorithm from the attestation format does not match the algorithm
     -- of the key in the credential data
     AlgorithmMismatch
-      { -- | The algorithm received in the attestation statement
-        statementAlg :: Cose.CoseSignAlg,
-        -- | The algorithm of the credentialPublicKey in authenticatorData
-        credentialAlg :: Cose.CoseSignAlg
-      }
+      -- | The algorithm received in the attestation statement
+      Cose.CoseSignAlg
+      -- | The algorithm of the credentialPublicKey in authenticatorData
+      Cose.CoseSignAlg
   | -- | The statement key cannot verify the signature over the attested
     -- credential data and client data for self attestation
     InvalidSignature Text
@@ -83,12 +82,11 @@ data VerificationError
   | -- | The AAGUID in the certificate extension does not match the AAGUID in
     -- the authenticator data
     CertificateAAGUIDMismatch
-      { -- | AAGUID from the id-fido-gen-ce-aaguid certificate extension
-        certificateExtensionAAGUID :: AAGUID,
-        -- | A AGUID from the attested credential data in the authenticator
-        -- data
-        attestedCredentialDataAAGUID :: AAGUID
-      }
+      -- | AAGUID from the id-fido-gen-ce-aaguid certificate extension
+      AAGUID
+      -- | A AGUID from the attested credential data in the authenticator
+      -- data
+      AAGUID
   deriving (Show, Exception)
 
 instance M.AttestationStatementFormat Format where

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/TPM.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/TPM.hs
@@ -518,23 +518,25 @@ instance M.AttestationStatementFormat Format where
             tpmtpParameters = TPMUPublicParmsRSA TPMSRSAParms {..},
             tpmtpUnique = TPM2BPublicKeyRSA (PrettyHexByteString nb)
           } =
-          Cose.checkPublicKey
+          Cose.checkPublicKey $
             Cose.PublicKeyRSA
-              { rsaN = os2ip nb,
-                rsaE = toInteger tpmsrpExponent
-              }
+              Cose.RSAPublicKey
+                { rsaN = os2ip nb,
+                  rsaE = toInteger tpmsrpExponent
+                }
       extractPublicKey
         TPMTPublic
           { tpmtpType = TPMAlgECC,
             tpmtpParameters = TPMUPublicParmsECC TPMSECCParms {..},
             tpmtpUnique = TPMUPublicIdECCPoint TPMSECCPoint {tpmseX = PrettyHexByteString tpmseX, tpmseY = PrettyHexByteString tpmseY}
           } =
-          Cose.checkPublicKey
+          Cose.checkPublicKey $
             Cose.PublicKeyECDSA
-              { ecdsaCurve = tpmsepCurveId,
-                ecdsaX = os2ip tpmseX,
-                ecdsaY = os2ip tpmseY
-              }
+              Cose.ECDSAPublicKey
+                { ecdsaCurve = tpmsepCurveId,
+                  ecdsaX = os2ip tpmseX,
+                  ecdsaY = os2ip tpmseY
+                }
       extractPublicKey key = Left $ "Unsupported TPM public key: " <> Text.pack (show key)
 
   asfEncode _ Statement {..} =

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/TPM.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/TPM.hs
@@ -246,11 +246,10 @@ data VerificationError
   = -- | The public key in the certificate is different from the on in the
     -- attested credential data
     PublicKeyMismatch
-      { -- | The public key extracted from the certificate
-        certificatePublicKey :: Cose.PublicKey,
-        -- | The public key part of the credential data
-        credentialDataPublicKey :: Cose.PublicKey
-      }
+      -- | The public key extracted from the certificate
+      Cose.PublicKey
+      -- | The public key part of the credential data
+      Cose.PublicKey
   | -- | The magic number in certInfo was not set to TPM_GENERATED_VALUE (0xff544347)
     MagicNumberInvalid Word32
   | -- | The type in certInfo was not set to TPM_ST_ATTEST_CERTIFY (0x8017)
@@ -260,13 +259,12 @@ data VerificationError
     NameAlgorithmInvalid TPMAlgId
   | -- | The calulated name does not match the provided name.
     NameMismatch
-      { -- | The name calculated from the TPMT_PUBLIC structure with the name
-        -- algorithm.
-        pubAreaName :: BS.ByteString,
-        -- | The expected name from TPMS_CERTIFY_INFO of the TPMS_ATTEST
-        -- structure
-        certifyInfoName :: BS.ByteString
-      }
+      -- | The name calculated from the TPMT_PUBLIC structure with the name
+      -- algorithm.
+      BS.ByteString
+      -- | The expected name from TPMS_CERTIFY_INFO of the TPMS_ATTEST
+      -- structure
+      BS.ByteString
   | -- | The public key in the certificate was invalid, either because the it
     -- had an unexpected algorithm, or because it was otherwise malformed
     PublicKeyInvalid Text
@@ -286,11 +284,10 @@ data VerificationError
   | -- | The AAGUID in the attested credential data does not match the AAGUID
     -- in the fido certificate extension
     CertificateAAGUIDMismatch
-      { -- | AAGUID from the id-fido-gen-ce-aaguid certificate extension
-        certificateExtensionAAGUID :: AAGUID,
-        -- | AAGUID from the attested credential data
-        attestedCredentialDataAAGUID :: AAGUID
-      }
+      -- | AAGUID from the id-fido-gen-ce-aaguid certificate extension
+      AAGUID
+      -- | AAGUID from the attested credential data
+      AAGUID
   | -- | The (supposedly) ASN1 encoded certificate extension could not be
     -- decoded
     ASN1Error ASN1Error
@@ -301,13 +298,12 @@ data VerificationError
   | -- | The calculated hash over the attToBeSigned does not match the received
     -- hash
     HashMismatch
-      { -- | The hash of the concatenation of the @authenticatorData@ and
-        -- @clientDataHash@ (@attToBeSigned@) calculated by the @alg@ specified in
-        -- the @Statement@.
-        calculatedHash :: BS.ByteString,
-        -- | The extra data from the TPMS_ATTEST structure.
-        extraData :: BS.ByteString
-      }
+      -- | The hash of the concatenation of the @authenticatorData@ and
+      -- @clientDataHash@ (@attToBeSigned@) calculated by the @alg@ specified in
+      -- the @Statement@.
+      BS.ByteString
+      -- | The extra data from the TPMS_ATTEST structure.
+      BS.ByteString
   deriving (Show, Exception)
 
 -- [(spec)](https://www.trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf)

--- a/src/Crypto/WebAuthn/Operation/Authentication.hs
+++ b/src/Crypto/WebAuthn/Operation/Authentication.hs
@@ -42,57 +42,51 @@ import Data.Validation (Validation)
 data AuthenticationError
   = -- | The provided Credential was not one explicitly allowed by the server
     AuthenticationCredentialDisallowed
-      { -- | The credentials allowed by the server
-        aeAllowedCredentials :: [M.CredentialDescriptor],
-        -- | The credential returned by the client
-        aeReceivedCredential :: M.Credential 'M.Authentication 'True
-      }
+      -- | The credentials allowed by the server
+      [M.CredentialDescriptor]
+      -- | The credential returned by the client
+      (M.Credential 'M.Authentication 'True)
   | -- | The received credential does not match the currently identified user
     AuthenticationIdentifiedUserHandleMismatch
-      { -- | The `M.UserHandle` of the user who is attempting authentication
-        aeIdentifiedUser :: M.UserHandle,
-        -- | The owner of the credential passed to the
-        -- `verifyAuthenticationResponse` function (retrieved from the
-        -- database)
-        aeRegisteredUser :: M.UserHandle
-      }
+      -- | The `M.UserHandle` of the user who is attempting authentication
+      M.UserHandle
+      -- | The owner of the credential passed to the
+      -- `verifyAuthenticationResponse` function (retrieved from the
+      -- database)
+      M.UserHandle
   | -- | The stored credential does not match the user specified in the
     -- response
     AuthenticationCredentialUserHandleMismatch
-      { -- | The `M.UserHandle` of the user who is attempting authentication
-        aeIdentifiedUser :: M.UserHandle,
-        -- | The `M.UserHandle` reported by the authenticator in the response
-        aeAuthenticatorUser :: M.UserHandle
-      }
+      -- | The `M.UserHandle` of the user who is attempting authentication
+      M.UserHandle
+      -- | The `M.UserHandle` reported by the authenticator in the response
+      M.UserHandle
   | -- | No user was identified and the response did not specify a user
     AuthenticationCannotVerifyUserHandle
   | -- | The received challenge does not match the originally created
     -- challenge
     AuthenticationChallengeMismatch
-      { -- | The challenge created by the relying party and part of the
-        -- `M.CredentialOptions`
-        aeCreatedChallenge :: M.Challenge,
-        -- | The challenge received from the client, part of the response
-        aeReceivedChallenge :: M.Challenge
-      }
+      -- | The challenge created by the relying party and part of the
+      -- `M.CredentialOptions`
+      M.Challenge
+      -- | The challenge received from the client, part of the response
+      M.Challenge
   | -- | The origin derived by the client does match any of the assumed origins
     AuthenticationOriginMismatch
-      { -- | The origins explicitly passed to the `verifyAuthenticationResponse`
-        -- response, set by the RP
-        aeExpectedOrigins :: NonEmpty M.Origin,
-        -- | The origin received from the client as part of the client data
-        aeReceivedOrigin :: M.Origin
-      }
+      -- | The origins explicitly passed to the `verifyAuthenticationResponse`
+      -- response, set by the RP
+      (NonEmpty M.Origin)
+      -- | The origin received from the client as part of the client data
+      M.Origin
   | -- | The rpIdHash in the authData is not a valid hash over the RpId
     -- expected by the Relying party
     AuthenticationRpIdHashMismatch
-      { -- | The RP ID hash explicitly passed to the
-        -- `verifyAuthenticationResponse` response, set by the RP
-        aeExpectedRpIdHash :: M.RpIdHash,
-        -- | The RP ID hash received from the client as part of the authenticator
-        -- data
-        aeReceivedRpIdHash :: M.RpIdHash
-      }
+      -- | The RP ID hash explicitly passed to the
+      -- `verifyAuthenticationResponse` response, set by the RP
+      M.RpIdHash
+      -- | The RP ID hash received from the client as part of the authenticator
+      -- data
+      M.RpIdHash
   | -- | The UserPresent bit was not set in the authData
     AuthenticationUserNotPresent
   | -- | The UserVerified bit was not set in the authData while user

--- a/src/Crypto/WebAuthn/Operation/Registration.hs
+++ b/src/Crypto/WebAuthn/Operation/Registration.hs
@@ -62,30 +62,27 @@ data RegistrationError
   = -- | The received challenge does not match the originally created
     -- challenge
     RegistrationChallengeMismatch
-      { -- | The challenge created by the relying party and part of the
-        -- `M.CredentialOptions`
-        reCreatedChallenge :: M.Challenge,
-        -- | The challenge received from the client, part of the response
-        reReceivedChallenge :: M.Challenge
-      }
+      -- | The challenge created by the relying party and part of the
+      -- `M.CredentialOptions`
+      M.Challenge
+      -- | The challenge received from the client, part of the response
+      M.Challenge
   | -- | The returned origin does not match any of the the relying party's origins
     RegistrationOriginMismatch
-      { -- | The origins explicitly passed to the `verifyRegistrationResponse`
-        -- response, set by the RP
-        reExpectedOrigins :: NonEmpty M.Origin,
-        -- | The origin received from the client as part of the client data
-        reReceivedOrigin :: M.Origin
-      }
+      -- | The origins explicitly passed to the `verifyRegistrationResponse`
+      -- response, set by the RP
+      (NonEmpty M.Origin)
+      -- | The origin received from the client as part of the client data
+      M.Origin
   | -- | The rpIdHash in the authData is not a valid hash over the RpId
     -- expected by the Relying party
     RegistrationRpIdHashMismatch
-      { -- | The RP ID hash explicitly passed to the
-        -- `verifyRegistrationResponse` response, set by the RP
-        reExpectedRpIdHash :: M.RpIdHash,
-        -- | The RP ID hash received from the client as part of the authenticator
-        -- data
-        reReceivedRpIdHash :: M.RpIdHash
-      }
+      -- | The RP ID hash explicitly passed to the
+      -- `verifyRegistrationResponse` response, set by the RP
+      M.RpIdHash
+      -- | The RP ID hash received from the client as part of the authenticator
+      -- data
+      M.RpIdHash
   | -- | The userpresent bit in the authdata was not set
     RegistrationUserNotPresent
   | -- | The userverified bit in the authdata was not set
@@ -93,11 +90,10 @@ data RegistrationError
   | -- | The algorithm received from the client was not one of the algorithms
     -- we (the relying party) requested from the client.
     RegistrationPublicKeyAlgorithmDisallowed
-      { -- | The signing algorithms requested by the RP
-        reAllowedSigningAlgorithms :: [Cose.CoseSignAlg],
-        -- | The signing algorithm received from the client
-        reReceivedSigningAlgorithm :: Cose.CoseSignAlg
-      }
+      -- | The signing algorithms requested by the RP
+      [Cose.CoseSignAlg]
+      -- | The signing algorithm received from the client
+      Cose.CoseSignAlg
   | -- | There was some exception in the statement format specific section
     forall a. (M.AttestationStatementFormat a) => RegistrationAttestationFormatError a (NonEmpty (M.AttStmtVerificationError a))
 


### PR DESCRIPTION
Subsumes #192 

All of these field accessors are partial functions that probably aren't necessary to keep around.