### PR TITLE
 Add backup eligible (BE) and backup state (BS) flags 

### DIFF
--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -954,14 +954,17 @@ data AuthenticatorDataFlags = AuthenticatorDataFlags
     -- the user is said to be "[verified](https://www.w3.org/TR/webauthn-3/#concept-user-verified)".
     adfUserVerified :: Bool,
     -- | [(spec)](https://www.w3.org/TR/webauthn-3/#backup-eligibility)
-    -- The backup eligibility (BE) flag. If set, the public key credential source
-    -- is backup eligible, meaning it can be backed up in some way (usually via
-    -- cloud sync of the authenticator's credentials).
+    -- The backup eligibility (BE) flag. If set, the credential is a
+    -- [multi-device credential](https://www.w3.org/TR/webauthn-3/#multi-device-credential).
+    -- If not set, the credential is a
+    -- [single-device credential](https://www.w3.org/TR/webauthn-3/#single-device-credential).
+    -- This value is set during registration and MUST NOT change.
     adfBackupEligible :: Bool,
     -- | [(spec)](https://www.w3.org/TR/webauthn-3/#backup-state)
-    -- The backup state (BS) flag. If set, the public key credential source
-    -- is currently backed up. This flag can change over time based on the
-    -- authenticator's state.
+    -- The backup state (BS) flag. If set, the credential is currently backed up.
+    -- This flag can change over time based on the current state of the
+    -- public key credential source. This flag can only be set if 'adfBackupEligible'
+    -- is also set; the combination @(BE=False, BS=True)@ is not allowed.
     adfBackupState :: Bool
   }
   deriving (Eq, Show, Generic)

--- a/src/Crypto/WebAuthn/Model/Types.hs
+++ b/src/Crypto/WebAuthn/Model/Types.hs
@@ -943,16 +943,26 @@ data AuthenticatorSelectionCriteria = AuthenticatorSelectionCriteria
 -- "Crypto.WebAuthn.Encoding" modules
 deriving instance ToJSON AuthenticatorSelectionCriteria
 
--- | [(spec)](https://www.w3.org/TR/webauthn-2/#flags)
+-- | [(spec)](https://www.w3.org/TR/webauthn-3/#flags)
 data AuthenticatorDataFlags = AuthenticatorDataFlags
-  { -- | [(spec)](https://www.w3.org/TR/webauthn-2/#concept-user-present)
-    -- Upon successful completion of a [user presence test](https://www.w3.org/TR/webauthn-2/#test-of-user-presence),
-    -- the user is said to be "[present](https://www.w3.org/TR/webauthn-2/#concept-user-present)".
+  { -- | [(spec)](https://www.w3.org/TR/webauthn-3/#concept-user-present)
+    -- Upon successful completion of a [user presence test](https://www.w3.org/TR/webauthn-3/#test-of-user-presence),
+    -- the user is said to be "[present](https://www.w3.org/TR/webauthn-3/#concept-user-present)".
     adfUserPresent :: Bool,
-    -- | [(spec)](https://www.w3.org/TR/webauthn-2/#concept-user-verified)
-    -- Upon successful completion of a [user verification](https://www.w3.org/TR/webauthn-2/#user-verification) process,
-    -- the user is said to be "[verified](https://www.w3.org/TR/webauthn-2/#concept-user-verified)".
-    adfUserVerified :: Bool
+    -- | [(spec)](https://www.w3.org/TR/webauthn-3/#concept-user-verified)
+    -- Upon successful completion of a [user verification](https://www.w3.org/TR/webauthn-3/#user-verification) process,
+    -- the user is said to be "[verified](https://www.w3.org/TR/webauthn-3/#concept-user-verified)".
+    adfUserVerified :: Bool,
+    -- | [(spec)](https://www.w3.org/TR/webauthn-3/#backup-eligibility)
+    -- The backup eligibility (BE) flag. If set, the public key credential source
+    -- is backup eligible, meaning it can be backed up in some way (usually via
+    -- cloud sync of the authenticator's credentials).
+    adfBackupEligible :: Bool,
+    -- | [(spec)](https://www.w3.org/TR/webauthn-3/#backup-state)
+    -- The backup state (BS) flag. If set, the public key credential source
+    -- is currently backed up. This flag can change over time based on the
+    -- authenticator's state.
+    adfBackupState :: Bool
   }
   deriving (Eq, Show, Generic)
 

--- a/tests/Spec/Types.hs
+++ b/tests/Spec/Types.hs
@@ -164,7 +164,7 @@ instance Arbitrary M.RpIdHash where
     pure $ M.RpIdHash $ hash rpId
 
 instance Arbitrary M.AuthenticatorDataFlags where
-  arbitrary = M.AuthenticatorDataFlags <$> arbitrary <*> arbitrary
+  arbitrary = M.AuthenticatorDataFlags <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 instance (SingI c) => Arbitrary (M.AttestedCredentialData c 'False) where
   arbitrary = case sing @c of


### PR DESCRIPTION
[Backup eligibility and backup state are added in the L3 spec](https://www.w3.org/TR/webauthn-3/#backup-eligible). An overview of these bits are detailed in the [Credential Backup State](https://www.w3.org/TR/webauthn-3/#sctn-credential-backup) section. The intention is that RPs will be able to use these bits to understand whether the credential is multi-device (and won't require any further registrations to protect against credential loss) or single-device (and can be used trigger another registration flow for safety).

## Backwards compatibility with L2

[These bits were reserved](https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data) in the L2 spec and credentials following the L2 spec will mark these bits as 0.