### PR TITLE
Deps update to crypton >= 1.1 + ram, crypton-x509 > 1.9, and jose 1.3

### DIFF
--- a/server/server.cabal
+++ b/server/server.cabal
@@ -39,7 +39,7 @@ executable server
     clock                 >= 0.8 && < 0.9,
     containers            >= 0.6.2 && < 0.9,
     cookie                >= 0.4.5 && < 0.6,
-    crypton               >= 1.0.6 && < 1.1,
+    crypton               >= 1.1,
     http-client           >= 0.6.4 && < 0.8,
     http-client-tls       >= 0.3.5 && < 0.4,
     http-types            >= 0.12.3 && < 0.13,

--- a/src/Crypto/WebAuthn/AttestationStatementFormat/AndroidSafetyNet.hs
+++ b/src/Crypto/WebAuthn/AttestationStatementFormat/AndroidSafetyNet.hs
@@ -147,7 +147,7 @@ newtype VerificationHostName = VerificationHostName {unVerificationHostName :: X
   deriving newtype (IsString)
 
 -- | This instance doesn't actually perform any validation
-instance (MonadError JOSE.Error m) => JOSE.VerificationKeyStore m (JOSE.JWSHeader ()) p VerificationHostName where
+instance (MonadError JOSE.Error m) => JOSE.VerificationKeyStore m (JOSE.JWSHeader JOSE.RequiredProtection) p VerificationHostName where
   getVerificationKeys header _ hostName = do
     chain <- case header ^? JOSE.x5c . _Just . JOSE.param of
       Nothing -> throwError JOSE.JWSInvalidSignature
@@ -196,7 +196,7 @@ instance M.AttestationStatementFormat Format where
         sig <- case jws ^? JOSE.signatures of
           Nothing -> Left "Can't extract x5c because the JWT contains no signatures"
           Just res -> pure res
-        JOSE.HeaderParam () x5c <- case sig ^. JOSE.header . JOSE.x5c of
+        JOSE.HeaderParam _ x5c <- case sig ^. JOSE.header . JOSE.x5c of
           Nothing -> Left "No x5c in the header of the first JWT signature"
           Just res -> pure res
         pure x5c

--- a/src/Crypto/WebAuthn/Metadata/Service/Processing.hs
+++ b/src/Crypto/WebAuthn/Metadata/Service/Processing.hs
@@ -37,7 +37,7 @@ import Crypto.JWT
     decodeCompact,
     defaultJWTValidationSettings,
     param,
-    verifyJWT,
+    verifyJWT, SignedJWTWithHeader,
   )
 import Crypto.WebAuthn.Internal.DateOrphans ()
 import qualified Crypto.WebAuthn.Metadata.Service.Types as Service
@@ -58,6 +58,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.X509 as X509
 import qualified Data.X509.CertificateStore as X509
 import qualified Data.X509.Validation as X509
+import qualified Crypto.JOSE as JOSE
 
 -- | A root certificate along with the host it should be verified against
 data RootCertificate = RootCertificate
@@ -114,7 +115,7 @@ fidoAllianceRootCertificate =
       Left err -> error err
       Right cert -> cert
 
-instance (MonadError ProcessingError m, MonadReader DateTime m) => VerificationKeyStore m (JWSHeader ()) p RootCertificate where
+instance (MonadError ProcessingError m, MonadReader DateTime m) => VerificationKeyStore m (JWSHeader JOSE.RequiredProtection) p RootCertificate where
   getVerificationKeys header _ (RootCertificate rootStore hostName) = do
     -- TODO: Implement step 4 of the spec, which says to try to get the chain
     -- from x5u first before trying x5c. See:
@@ -139,7 +140,12 @@ instance (MonadError ProcessingError m, MonadReader DateTime m) => VerificationK
     let validationErrors =
           X509.validatePure
             now
-            X509.defaultHooks
+            X509.defaultHooks {
+              X509.hookFilterReason = filter (\case
+                    X509.UnknownCriticalExtension oids -> all (`elem` [2,5,29,32]) oids
+                    _ -> False
+                  )
+            }
             X509.defaultChecks
             rootStore
             (hostName, "")
@@ -164,7 +170,7 @@ jwtToAdditionalData ::
   DateTime ->
   Either ProcessingError addData
 jwtToAdditionalData blob rootCert now = runExcept $ do
-  jwt <- decodeCompact $ LBS.fromStrict blob
+  jwt <- decodeCompact @(SignedJWTWithHeader JWSHeader) $ LBS.fromStrict blob
   payload <- runReaderT (verifyJWT (defaultJWTValidationSettings (const True)) rootCert jwt) now
   return $ Service.additionalData payload
 

--- a/src/Crypto/WebAuthn/Operation/Registration.hs
+++ b/src/Crypto/WebAuthn/Operation/Registration.hs
@@ -601,7 +601,11 @@ validateAttestationChain
         X509.validatePure
           currentTime
           X509.defaultHooks
-            { X509.hookValidateName = \_fqhn _cert -> []
+            { X509.hookValidateName = \_fqhn _cert -> [],
+              X509.hookFilterReason = filter (\case
+                    X509.UnknownCriticalExtension oids -> any (`notElem` [2,5,29,32]) oids
+                    _ -> False
+                  )
             }
           X509.defaultChecks
           (formatRootCerts <> metadataRootCerts)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -42,6 +42,7 @@ import System.FilePath ((</>))
 import Test.Hspec (Spec, describe, it, shouldSatisfy)
 import qualified Test.Hspec as Hspec
 import Test.QuickCheck.Instances.Text ()
+import Debug.Trace (trace)
 
 -- | Load all files in the given directory, and ensure that all of them can be
 -- decoded. The caller can pass in a function to run further checks on the
@@ -353,7 +354,7 @@ main = Hspec.hspec $ do
         registry
         HG.DateTime {dtDate = HG.Date {dateYear = 2021, dateMonth = HG.September, dateDay = 1}, dtTime = timeZero}
   describe "TPM register" $ do
-    it "tests whether the fixed TPM-SHA1 register has a valid attestation" $
+    it "tests whether the fixed TPM-SHA1 register for RS1 has a valid attestation" $
       registerTestFromFile
         "tests/responses/attestation/tpm-rs1-01.json"
         "https://webauthntest.azurewebsites.net"
@@ -361,7 +362,7 @@ main = Hspec.hspec $ do
         True
         registry
         predeterminedDateTime
-    it "tests whether the fixed TPM-SHA1 register has a valid attestation" $
+    it "tests whether the fixed TPM-SHA1 register for ECC256 has a valid attestation" $
       registerTestFromFile
         "tests/responses/attestation/tpm-es256-01.json"
         "https://localhost:44329"
@@ -381,7 +382,7 @@ main = Hspec.hspec $ do
 
 -- | Checks if the received attestation response if one we expect
 isExpectedAttestationResponse :: M.Credential 'M.Registration 'True -> M.CredentialOptions 'M.Registration -> Bool -> Either (NonEmpty O.RegistrationError) O.RegistrationResult -> Bool
-isExpectedAttestationResponse _ _ _ (Left _) = False -- We should never receive errors
+isExpectedAttestationResponse _ _ _ (Left _) = trace "Left False" False -- We should never receive errors
 isExpectedAttestationResponse M.Credential {..} M.CredentialOptionsRegistration {..} verifiable (Right O.RegistrationResult {..}) =
   rrEntry == expectedCredentialEntry
     && not verifiable

--- a/webauthn.cabal
+++ b/webauthn.cabal
@@ -35,7 +35,7 @@ description:
   however follow the [PVP](https://pvp.haskell.org/) and properly label changes
   with the appropriate version increase.
 category: Web, Authentication
-tested-with: GHC == 9.10.3
+tested-with: GHC == 9.6.7 || == 9.8.4 || == 9.10.3 || == 9.12.2
 extra-source-files:
   README.md,
   changelog.md,
@@ -70,26 +70,26 @@ library
   hs-source-dirs: src
   build-depends:
     base                    >= 4.13.0 && < 4.22,
-    aeson                   >= 2.0.1 && < 2.3,
+    aeson                   >= 1.4.7 && < 2.4,
     base16-bytestring       >= 1.0.0 && < 1.1,
     base64-bytestring       >= 1.2.1 && < 1.3,
     binary                  >= 0.8.7 && < 0.9,
     bytestring              >= 0.10.10 && < 0.13,
     cborg                   >= 0.2.4 && < 0.3,
     containers              >= 0.6.2.1 && < 0.9,
-    crypton                 >= 0.32 && < 1.1,
-    crypton-asn1-encoding   >= 0.9 && < 0.11,
-    crypton-asn1-parse      >= 0.9 && < 0.11,
+    crypton                 >= 1.1,
+    crypton-asn1-encoding   >= 0.10, 
+    crypton-asn1-parse      >= 0.10,
     crypton-asn1-types      >= 0.4.1 && < 0.5,
-    crypton-x509            >= 1.8 && < 1.9,
-    crypton-x509-store      >= 1.8 && < 1.9,
-    crypton-x509-validation >= 1.8 && < 1.9,
+    crypton-x509            >= 1.9.0,
+    crypton-x509-store      >= 1.9.0,
+    crypton-x509-validation >= 1.9.1,
     file-embed              >= 0.0.11 && < 0.1,
     hashable                >= 1.3.2 && < 1.6,
     time-hourglass          >= 0.2 && < 0.4,
-    jose                    >= 0.11 && < 0.12,
+    jose                    >= 0.13,
     lens                    >= 4.18.1 && < 5.4,
-    memory                  >= 0.15.0 && < 0.19,
+    ram                     >= 0.19,
     monad-time              >= 0.4.0 && < 0.5,
     mtl                     >= 2.2.2 && < 2.4,
     serialise               >= 0.2.3 && < 0.3,
@@ -179,7 +179,7 @@ test-suite tests
     time-hourglass,
     hspec,
     hspec-expectations-json,
-    memory,
+    ram,
     mtl,
     crypton-pem,
     quickcheck-instances,


### PR DESCRIPTION
Bounds updates and fixes. Based on another PR I read I have removed upper bounds - not sure if this is what you want.

Tested on  tested on GHC 9.6.7, 9.8.4, 9.10.3, 9.12.2.

TPM X.509 extension [2,5,29,32] had to be excluded, really not sure if this is acceptable. Seems like a bigger change if this extension needs to be checked.